### PR TITLE
[bug]batchnorm running mean var not updated

### DIFF
--- a/python/singa/autograd.py
+++ b/python/singa/autograd.py
@@ -1455,7 +1455,7 @@ class _BatchNorm2d(Operation):
 
                 self.cache = (x, scale, mean, var, y, bias)
             else:
-                y, mean, var = singa.GpuBatchNormForwardTraining(
+                y, mean, var, self.running_mean, self.running_var = singa.GpuBatchNormForwardTraining(
                     self.handle, x, scale, bias, self.running_mean, self.running_var
                 )
 

--- a/src/model/operation/batchnorm.cc
+++ b/src/model/operation/batchnorm.cc
@@ -300,7 +300,7 @@ const std::vector<Tensor> GpuBatchNormForwardTraining(const CudnnBatchNormHandle
     mean.block(), var.block()
   });
   if (cbnh.is_2d) output.Reshape(Shape{shape.at(0), shape.at(1)});
-  return {output, mean, var};
+  return {output, mean, var, running_mean, running_var};
 }
 
 Tensor GpuBatchNormForwardInference(const CudnnBatchNormHandle &cbnh,


### PR DESCRIPTION
Hi team,
Shouldn't `autograd` `batchnorm`  class update its running_mean and running_var from c++ backend? I could not find anywhere `running_mean/var` are updated.