### PR TITLE
SINGA-487 Fusing gradients to reduce network latency

### DIFF
--- a/examples/autograd/mnist_cnn.py
+++ b/examples/autograd/mnist_cnn.py
@@ -113,14 +113,14 @@ def accuracy(pred, target):
 # Function to all reduce NUMPY Accuracy and Loss from Multiple Devices
 def reduce_variable(variable, dist_opt, reducer):
     reducer.copy_from_numpy(variable)
-    singa.synch(reducer.data, dist_opt.communicator)
+    dist_opt.all_reduce(reducer.data)
     dist_opt.wait()
     output=tensor.to_numpy(reducer)
     return output
 
 # Function to sychronize SINGA TENSOR initial model parameters
 def sychronize(tensor, dist_opt):
-    singa.synch(tensor.data, dist_opt.communicator)
+    dist_opt.all_reduce(tensor.data)
     tensor /= dist_opt.world_size
 
 # Data augmentation
@@ -135,7 +135,6 @@ def augmentation(x, batch_size):
     return x
 
 def train_mnist_cnn(sgd, max_epoch, batch_size, DIST=False, data_partition=None, gpu_num=None, gpu_per_node=None, nccl_id=None):
-
     # Prepare training and valadiation data
     train_x, train_y, test_x, test_y = load_dataset()
     IMG_SIZE = 28
@@ -205,15 +204,10 @@ def train_mnist_cnn(sgd, max_epoch, batch_size, DIST=False, data_partition=None,
             loss = autograd.softmax_cross_entropy(out, ty)               
             train_correct += accuracy(tensor.to_numpy(out), y)
             train_loss += tensor.to_numpy(loss)[0]
-            plist = []
-            for p, g in autograd.backward(loss):
-                if DIST:
-                    sgd.all_reduce(g)
-                plist.append((p, g))
             if DIST:
-                sgd.wait()
-            for p, g in plist:
-                sgd.update(p, g)  
+                sgd.backward_and_update(loss, threshold = 50000)
+            else:
+                sgd.backward_and_update(loss)
 
         if DIST:
             # Reduce the Evaluation Accuracy and Loss from Multiple Devices

--- a/examples/autograd/resnet_dist.py
+++ b/examples/autograd/resnet_dist.py
@@ -69,10 +69,6 @@ if __name__ == "__main__":
             loss = autograd.softmax_cross_entropy(x, ty)
             dev.Sync()
             softmax += time.time() - tick
-            plist = []
-            acc = 0
-            glist = []
-            tsize = []
             sgd.backward_and_update(loss)
 
     dev.Sync()            

--- a/examples/autograd/resnet_dist.py
+++ b/examples/autograd/resnet_dist.py
@@ -70,16 +70,10 @@ if __name__ == "__main__":
             dev.Sync()
             softmax += time.time() - tick
             plist = []
-            for p, g in autograd.backward(loss):
-                #dev.Sync()  # this Sync affects the concurrency and hence omitted
-                tick = time.time()
-                sgd.all_reduce(g)
-                #dev.Sync()  # this Sync affects the concurrency and hence omitted
-                update += time.time() - tick
-                plist.append((p, g))
-            sgd.wait()
-            for p, g in plist:
-                sgd.update(p, g)  
+            acc = 0
+            glist = []
+            tsize = []
+            sgd.backward_and_update(loss)
 
     dev.Sync()            
     end = time.time()
@@ -88,9 +82,8 @@ if __name__ == "__main__":
     tforward = float(fd) / float(niters)
     tsoftmax = float(softmax) / float(niters)
     tbackward = titer - tforward - tsoftmax
-    tsgd = float(update) / float(niters)
 
     if (sgd.rank_in_global == 0):
         print("\nThroughput = {} per second".format(throughput), flush=True)
-        print("Total={}, forward={}, softmax={}, backward={}, sgd={}".format(
-        titer, tforward, tsoftmax, tbackward, tsgd), flush=True)
+        print("Total={}, forward={}, softmax={}, backward={}".format(
+        titer, tforward, tsoftmax, tbackward), flush=True)

--- a/include/singa/io/communicator.h
+++ b/include/singa/io/communicator.h
@@ -30,6 +30,7 @@
 #include <mpi.h>
 
 #include "singa/core/tensor.h"
+using std::vector;
 
 namespace singa{
 
@@ -64,19 +65,29 @@ public:
   int totalMPIRanksInGlobal;
   int MPIRankInLocal;
   bool UseMPI;
+  float *fusedSendBuff;
+  float *fusedRecvBuff;
+  size_t maxSize;
 
   ncclUniqueId id;
   cudaStream_t s;
+  cudaStream_t c;
   ncclComm_t comm;
   cudaEvent_t event;
-  Communicator();
-  Communicator(int gpu_num, int gpu_per_node, const NcclIdHolder &holder);
+
+  Communicator(int limit);
+  Communicator(int gpu_num, int gpu_per_node, const NcclIdHolder &holder, int size);
   ~Communicator();
-  void allReduce(int size, void* sendbuff, void* recvbuff);
+  void synch(Tensor &t);
+  void fusedSynch(vector<Tensor> &t);
   void wait();
+
+private:
+  void allReduce(int size, void* sendbuff, void* recvbuff);
+  void setup(int gpu_num);
+
 };
 
-void synch(Tensor &t, Communicator &c);
 
 }
 

--- a/python/singa/opt.py
+++ b/python/singa/opt.py
@@ -19,6 +19,7 @@
 It replaces the old optimizers from optimizer.py'''
 
 from singa import tensor
+from singa import autograd
 from . import singa_wrap as singa
 
 
@@ -159,10 +160,14 @@ class SGD(Optimizer):
                 grad = buf
         singa.Axpy(-group['lr'], grad.data, param.data)
 
+    def backward_and_update(self, loss):
+        for p, g in autograd.backward(loss):
+            self.update(p, g)
+
 
 class DistOpt(object):
 
-    def __init__(self, opt=SGD(), nccl_id=None, gpu_num=None, gpu_per_node=None):
+    def __init__(self, opt=SGD(), nccl_id=None, gpu_num=None, gpu_per_node=None, buffSize=4194304):
         # The class is designed to wrap an optimizer to do disttributed training.
         # opt: The optimizer to be wrapped. nDev: number of devices(GPUs) a
         # process will control/use.
@@ -174,10 +179,10 @@ class DistOpt(object):
         self.opt = opt
         if nccl_id is None:
             # constructure for application using MPI
-            self.communicator = singa.Communicator()
+            self.communicator = singa.Communicator(buffSize)
         else:
             # constructor for application using python multi-process module
-            self.communicator = singa.Communicator(gpu_num, gpu_per_node, nccl_id)
+            self.communicator = singa.Communicator(gpu_num, gpu_per_node, nccl_id, buffSize)
 
         self.world_size = self.communicator.totalMPIRanksInGlobal
         self.rank_in_local = self.communicator.MPIRankInLocal
@@ -188,7 +193,34 @@ class DistOpt(object):
         self.opt.update(param, grad)
 
     def all_reduce(self, tensor):
-        singa.synch(tensor.data, self.communicator)
+        self.communicator.synch(tensor)
+
+    def fused_all_reduce(self, tensor):
+        tensor = singa.VecTensor(tensor)
+        self.communicator.fusedSynch(tensor)
 
     def wait(self):
         self.communicator.wait()
+
+    def backward_and_update(self, loss, threshold = 2097152):
+        plist = []
+        acc = 0
+        glist = []
+        for p, g in autograd.backward(loss):
+            if g.size() > threshold:
+                # larger than threshold -> reduced directly
+                self.all_reduce(g.data)
+            else:
+                # smaller than threshold -> accumulate
+                glist.append(g.data)                    
+                acc += g.size()
+                if (acc > threshold):
+                    self.fused_all_reduce(glist)
+                    acc = 0
+                    glist = []
+            plist.append((p, g))
+        if glist:
+            self.fused_all_reduce(glist)
+        self.wait()
+        for p, g in plist:
+            self.update(p, g)  

--- a/src/api/dist_communicator.i
+++ b/src/api/dist_communicator.i
@@ -22,6 +22,7 @@
 /*interface file for swig */
 
 %module dist_communicator
+%include "std_vector.i"
 
 %{
 #include "singa/io/communicator.h"
@@ -42,12 +43,13 @@ public:
   int MPIRankInGlobal;
   int totalMPIRanksInGlobal;
   int MPIRankInLocal;
-  Communicator(int gpu_num, int gpu_per_node, const NcclIdHolder &holder);
-  Communicator();
+  Communicator(int limit);
+  Communicator(int gpu_num, int gpu_per_node, const NcclIdHolder &holder, int limit);
+  void synch(Tensor &t);
+  void fusedSynch(std::vector<Tensor> &t);
   void wait();
 };
 
-void synch(Tensor &t, Communicator &c);
 
 #endif  // USE_DIST
 


### PR DESCRIPTION
This PR reduces the network latency by fusing gradients in the same memory buffer before sending out with NCCL.
This can reduce much of the TCP/IP latency by reducing the number of NCCL API call.

Together with the result of PR #555, here is a simple test to make sure the training is correct:
```
ubuntu@ip-172-31-26-214:~/singa/examples/autograd$ python3 mnist_multiprocess.py
Starting Epoch 0:
Training loss = 831.072205, training accuracy = 0.700454
Evaluation accuracy = 0.927015, Elapsed Time = 0.676089s
Starting Epoch 1:
Training loss = 248.684601, training accuracy = 0.916183
Evaluation accuracy = 0.958265, Elapsed Time = 0.545179s
Starting Epoch 2:
Training loss = 172.330597, training accuracy = 0.943042
Evaluation accuracy = 0.967928, Elapsed Time = 0.543617s
Starting Epoch 3:
Training loss = 139.254807, training accuracy = 0.953425
Evaluation accuracy = 0.973067, Elapsed Time = 0.530805s
Starting Epoch 4:
Training loss = 115.329491, training accuracy = 0.960737
Evaluation accuracy = 0.976049, Elapsed Time = 0.530590s
Starting Epoch 5:
Training loss = 101.911728, training accuracy = 0.966179
Evaluation accuracy = 0.974095, Elapsed Time = 0.529574s
Starting Epoch 6:
Training loss = 90.820244, training accuracy = 0.969969
Evaluation accuracy = 0.980983, Elapsed Time = 0.530502s
Starting Epoch 7:
Training loss = 86.718071, training accuracy = 0.971037
Evaluation accuracy = 0.977590, Elapsed Time = 0.531085s
Starting Epoch 8:
Training loss = 79.507553, training accuracy = 0.973675
Evaluation accuracy = 0.976562, Elapsed Time = 0.529935s
Starting Epoch 9:
Training loss = 78.784409, training accuracy = 0.974025
Evaluation accuracy = 0.980469, Elapsed Time = 0.530919s
```