### PR TITLE
hotfix: cpp softmax not impl

### DIFF
--- a/examples/autograd/mlp.py
+++ b/examples/autograd/mlp.py
@@ -84,8 +84,7 @@ if __name__ == "__main__":
         x = autograd.relu(x)
         x = autograd.matmul(x, w1)
         x = autograd.add_bias(x, b1)
-        x = autograd.softmax(x)
-        loss = autograd.cross_entropy(x, target)
+        loss = autograd.softmax_cross_entropy(x, target)
         for p, gp in autograd.backward(loss):
             sgd.apply(0, gp, p, "")
 

--- a/src/core/tensor/tensor_math_cuda.h
+++ b/src/core/tensor/tensor_math_cuda.h
@@ -939,40 +939,6 @@ void SoftMax<float, lang::Cuda>(const Tensor &in, Tensor *out, Context* ctx) {
                                   , generate_tensor_nd_desc(tmp), outPtr));
 }
 
-// add axis to softmax API according to ONNX specification
-// https://github.com/onnx/onnx/blob/master/docs/Operators.md#Softmax
-template <>
-void SoftMax<float, lang::Cuda>(const Tensor &in, Tensor *out, Context* ctx, int axis) {
-  // {a_0, a_1, ..., a_k-1, a_k, ... a_n-1}
-  // reshape to
-  // { a_0 * a_1 * ... a_k-1, a_k * ... a_n-1 }
-
-  // assert axis \in {-r, r-1}
-  CHECK_LE(axis, (int)in.shape().size()-1 );
-  CHECK_GE(axis, -1*(int)in.nDim() );
-
-  Shape original_shape = in.shape();
-  if (axis < 0) axis = in.shape().size() + axis;
-
-  Shape coerced_shape = {1, 1};
-  for (std::size_t i = 0, max = in.shape().size(); i != max; ++i) {
-      if (i < axis)
-        coerced_shape[0] *= in.shape()[i];
-      else
-        coerced_shape[1] *= in.shape()[i];
-  }
-  Tensor in_reshaped = Reshape(in, coerced_shape);
-  out->Reshape(coerced_shape);
-
-  // optimise by minus x - x.max()
-  auto in_max = RowMax(in_reshaped);
-  in_max.Reshape({coerced_shape[0],1});
-  in_reshaped = in_reshaped - in_max;
-
-  SoftMax<float, lang::Cuda>(in_reshaped, out, ctx);
-
-  out->Reshape(original_shape);
-}
 
 template <>
 void ComputeCrossEntropy<float, lang::Cuda>(bool int_target,

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -170,10 +170,10 @@ class TestAPI(unittest.TestCase):
         _run_testing(x_0, s_0, b_0, rm_0, rv_0, m_0=1.0)
 
     def test_softmax_api(self):
-        def _run_test(org_shape, axis, aft_shape):
+        def _run_test(dev, org_shape, axis, aft_shape):
             x_0 = np.random.random(org_shape).astype(np.float32)
             x_0 = x_0 + 1000
-            x0 = tensor.Tensor(device=gpu_dev, data=x_0)
+            x0 = tensor.Tensor(device=dev, data=x_0)
 
             # test with axis
             y0 = tensor._call_singa_func(singa_api.SoftMax, x0.data, axis)
@@ -189,26 +189,26 @@ class TestAPI(unittest.TestCase):
 
             np.testing.assert_array_almost_equal(tensor.to_numpy(y0), y1)
 
-        _run_test([2, 2], 1, [2, 2])
-        _run_test([2, 2], 0, [1, 4])
-        _run_test([2, 2], -1, [2, 2])
-        _run_test([2, 2], -2, [1, 4])
 
-        _run_test([2, 2, 2], 2, [4, 2])
-        _run_test([2, 2, 2], 1, [2, 4])
-        _run_test([2, 2, 2], 0, [1, 8])
-        _run_test([2, 2, 2], -1, [4, 2])
-        _run_test([2, 2, 2], -2, [2, 4])
-        _run_test([2, 2, 2], -3, [1, 8])
-
-        _run_test([2, 2, 2, 2], 3, [8, 2])
-        _run_test([2, 2, 2, 2], 2, [4, 4])
-        _run_test([2, 2, 2, 2], 1, [2, 8])
-        _run_test([2, 2, 2, 2], 0, [1, 16])
-        _run_test([2, 2, 2, 2], -1, [8, 2])
-        _run_test([2, 2, 2, 2], -2, [4, 4])
-        _run_test([2, 2, 2, 2], -3, [2, 8])
-        _run_test([2, 2, 2, 2], -4, [1, 16])
+        for dev in [gpu_dev, cpu_dev]:
+            _run_test(dev, [2, 2], 1, [2, 2])
+            _run_test(dev, [2, 2], 0, [1, 4])
+            _run_test(dev, [2, 2], -1, [2, 2])
+            _run_test(dev, [2, 2], -2, [1, 4])
+            _run_test(dev, [2, 2, 2], 2, [4, 2])
+            _run_test(dev, [2, 2, 2], 1, [2, 4])
+            _run_test(dev, [2, 2, 2], 0, [1, 8])
+            _run_test(dev, [2, 2, 2], -1, [4, 2])
+            _run_test(dev, [2, 2, 2], -2, [2, 4])
+            _run_test(dev, [2, 2, 2], -3, [1, 8])
+            _run_test(dev, [2, 2, 2, 2], 3, [8, 2])
+            _run_test(dev, [2, 2, 2, 2], 2, [4, 4])
+            _run_test(dev, [2, 2, 2, 2], 1, [2, 8])
+            _run_test(dev, [2, 2, 2, 2], 0, [1, 16])
+            _run_test(dev, [2, 2, 2, 2], -1, [8, 2])
+            _run_test(dev, [2, 2, 2, 2], -2, [4, 4])
+            _run_test(dev, [2, 2, 2, 2], -3, [2, 8])
+            _run_test(dev, [2, 2, 2, 2], -4, [1, 16])
 
     def test_tensor_arithmetic_op_broadcast(self):
         def _run_test(dev, singa_op, np_op, s1, s2):


### PR DESCRIPTION
moved `softmax(..., axis)` implementation one level up, from cuda to tensor. After the change, `softmax(..., axis)` implemenation could serve for both cuda and cpp. Tested is added accordingly.