### PR TITLE
SINGA-502 Avoid moving data between host and gpu in SoftmaxCrossEntropy

### DIFF
--- a/include/singa/core/tensor.h
+++ b/include/singa/core/tensor.h
@@ -553,6 +553,7 @@ void SumRows(const Tensor &M, Tensor *out);
 /// if 'axis' is 1, sum all columns into a single column
 /// TODO(wangwei) support arbitrary Tensor like numpy.sum
 Tensor Sum(const Tensor &in, const int axis);
+Tensor SumAll(const Tensor &in);
 
 // ================Random operations==========================================
 /// For each element x set x = 1 if random() < p; otherwise x = 1.

--- a/python/singa/autograd.py
+++ b/python/singa/autograd.py
@@ -925,9 +925,8 @@ class CrossEntropy(Operation):
         Returns:
             loss (CTensor): scalar.
         """
-        loss = CTensor((1,))
-        loss_data = -singa.SumAsFloat(singa.__mul__(t, singa.Log(x)))
-        loss.SetFloatValue(loss_data / x.shape()[0])
+        loss = singa.SumAll(singa.__mul__(t, singa.Log(x)))
+        loss /= -x.shape()[0]
         self.x = x
         self.t = t
         self.input = (x, t)
@@ -944,7 +943,7 @@ class CrossEntropy(Operation):
                           dy = 1.0
         """
         dx = singa.__div__(self.t, self.x)
-        dx *= float(-1 / self.x.shape()[0])
+        dx *= float(-1.0 / self.x.shape()[0])
         if isinstance(dy, float):
             # dtype of dy: float
             dx *= dy
@@ -964,9 +963,9 @@ class SoftMaxCrossEntropy(Operation):
 
     def forward(self, x):
         self.p = singa.SoftMax(x)
-        loss = CTensor((1,), self.p.device())
         ret = singa.CrossEntropyFwd(self.p, self.t)
-        loss.SetFloatValue(singa.SumAsFloat(ret) / x.shape()[0])
+        loss = singa.SumAll(ret)
+        loss /= x.shape()[0]
         return loss
 
     def backward(self, dy=1.0):
@@ -987,8 +986,8 @@ class MeanSquareError(Operation):
     def forward(self, x, t):
         self.err = singa.__sub__(x, t)
         sqr = singa.Square(self.err)
-        loss = CTensor((1,), x.device())
-        loss.SetFloatValue(singa.SumAsFloat(sqr) / x.shape()[0] / 2)
+        loss = singa.SumAll(sqr)
+        loss /= (x.shape()[0] * 2)
         return loss
 
     def backward(self, dy=1.0):

--- a/src/api/core_tensor.i
+++ b/src/api/core_tensor.i
@@ -196,6 +196,7 @@ namespace singa{
   Tensor Sum(const Tensor &t, int axis);
   template <typename SType> SType Sum(const Tensor &t);
   %template(SumAsFloat) Sum<float>;
+  Tensor SumAll(const Tensor &t);
 
   Tensor Average(const Tensor &t, int axis);
   Tensor SoftMax(const Tensor &t);

--- a/src/core/tensor/tensor.cc
+++ b/src/core/tensor/tensor.cc
@@ -940,6 +940,19 @@ Tensor Sum(const Tensor &M, int axis) {
   }
 }
 
+Tensor SumAll(const Tensor &in) {
+  Tensor out({(size_t)1}, in.device(), in.data_type());
+  Tensor one(in.shape(), in.device(), in.data_type());
+  auto *outPtr = &out;
+  one.SetValue(1.0f);
+  TYPE_LANG_SWITCH(in.data_type(), DType, in.device()->lang(), Lang, {
+    one.device()->Exec([in, one, outPtr](Context * ctx) {
+      Dot<DType, Lang>(in, one, outPtr, ctx);
+    }, {in.block(), one.block()}, {outPtr->block()});
+  });
+  return out;
+}
+ 
 Tensor RowMax(const Tensor &in) {
   Tensor ret({in.shape(0)}, in.device(), in.data_type());
   TYPE_LANG_SWITCH(in.data_type(), DType, in.device()->lang(), Lang, {

--- a/src/core/tensor/tensor_math.h
+++ b/src/core/tensor/tensor_math.h
@@ -391,6 +391,11 @@ void Dot(const Tensor &in1, const Tensor &in2, DType *out,
          Context *ctx) {
   LOG(FATAL) << "Dot Not Implemented";
 }
+template <typename DType, typename Lang>
+void Dot(const Tensor &in1, const Tensor &in2, Tensor *out,
+         Context *ctx) {
+  LOG(FATAL) << "Dot Not Implemented";
+}
 
 /// out = alpha * A * v + beta * out.
 /// transA indicates if the internal data layout is transposed of A

--- a/src/core/tensor/tensor_math_cpp.h
+++ b/src/core/tensor/tensor_math_cpp.h
@@ -649,6 +649,19 @@ void Dot<float, lang::Cpp>(const Tensor& in1, const Tensor& in2,
     LOG(FATAL) << "Dot, one of the input is tranposed. Not implemented yet." ;
   }
 }
+template <>
+void Dot<float, lang::Cpp>(const Tensor& in1, const Tensor& in2,
+                           Tensor *out, Context *ctx) {
+  //check input tensor for strides first
+  if (!(in1.transpose()) && !(in2.transpose())) {
+    const float *in1Ptr = static_cast<const float *>(in1.block()->data());
+    const float *in2Ptr = static_cast<const float *>(in2.block()->data());
+    float* outPtr = static_cast<float*>(out->block()->mutable_data());
+    *outPtr = cblas_sdot(in1.Size(), in1Ptr, 1, in2Ptr, 1);
+  } else {
+    LOG(FATAL) << "Dot, one of the input is tranposed. Not implemented yet." ;
+  }
+}
 
 template <>
 void Scale<float, lang::Cpp>(const float x, Tensor *out,

--- a/src/core/tensor/tensor_math_cuda.h
+++ b/src/core/tensor/tensor_math_cuda.h
@@ -834,6 +834,19 @@ void Dot<float, lang::Cuda>(const Tensor& in1,
   CUBLAS_CHECK(cublasSdot(handle, num, inPtr1, 1, inPtr2, 1, out));
 }
 template <>
+void Dot<float, lang::Cuda>(const Tensor& in1,
+                            const Tensor& in2, Tensor* out, Context* ctx) {
+  const float* inPtr1 = static_cast<const float*>(in1.block()->data());
+  const float* inPtr2 = static_cast<const float*>(in2.block()->data());
+  float* outPtr = static_cast<float*>(out->block()->mutable_data());
+  auto handle = ctx->cublas_handle;
+  const size_t num = in1.Size();
+  CUBLAS_CHECK(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE));
+  CUBLAS_CHECK(cublasSdot(handle, num, inPtr1, 1, inPtr2, 1, outPtr));
+  CUBLAS_CHECK(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST));
+}
+
+template <>
 void Nrm2<float, lang::Cuda>(const Tensor& in, float* out,
                              Context* ctx) {
   auto handle = ctx->cublas_handle;  // TODO(wangwei) set cudastream


### PR DESCRIPTION
The softmax_cross_entropy move to data to host and then back to gpu, so the whole function needed to be changed for many reasons such as efficiency and asynchronization (and buffering operation in the future). :

class SoftMaxCrossEntropy(Operation): 

def _init_(self, t): 
  super(SoftMaxCrossEntropy, self)._init_() 
  self.t = t.data

def forward(self, x): 
  self.p = singa.SoftMax 
  loss = CTensor((1,), self.p.device()) 
  ret = singa.CrossEntropyFwd(self.p, self.t) 
  loss.SetFloatValue(singa.SumAsFloat(ret) / x.shape()[0]) 
  return loss

Here the SumAsFloat return a c++ float value, and this value is read back to gpu in the SetFloatValue function.
