### PR TITLE
SINGA-505 SoftMax Backward to be bufferable

### DIFF
--- a/include/singa/core/tensor.h
+++ b/include/singa/core/tensor.h
@@ -514,6 +514,7 @@ void MultRow(const Tensor &v, Tensor *M);
 /// Do softmax for each row. 'in' could be a 1-d or 2-d Tensor.
 Tensor SoftMax(const Tensor &in);
 Tensor SoftMax(const Tensor &in, int axis);
+Tensor SoftMaxBackward(const Tensor &in, int axis, const Tensor &fdout);
 
 Tensor RowMax(const Tensor &in);
 /// Do softmax for each row. 'in' could be a 1-d or 2-d Tensor.

--- a/src/api/core_tensor.i
+++ b/src/api/core_tensor.i
@@ -201,6 +201,7 @@ namespace singa{
   Tensor Average(const Tensor &t, int axis);
   Tensor SoftMax(const Tensor &t);
   Tensor SoftMax(const Tensor &t, int axis);
+  Tensor SoftMaxBackward(const Tensor &t, int axis, const Tensor &fdout);
 
   Tensor Pow(const Tensor &base, const Tensor &exp);
 

--- a/src/core/tensor/tensor_math.h
+++ b/src/core/tensor/tensor_math.h
@@ -369,8 +369,7 @@ void Dot(const Tensor &in1, const Tensor &in2, DType *out, Context *ctx) {
   LOG(FATAL) << "Dot Not Implemented";
 }
 template <typename DType, typename Lang>
-void Dot(const Tensor &in1, const Tensor &in2, Tensor *out,
-         Context *ctx) {
+void Dot(const Tensor &in1, const Tensor &in2, Tensor *out, Context *ctx) {
   LOG(FATAL) << "Dot Not Implemented";
 }
 
@@ -404,7 +403,8 @@ void SoftMax(const Tensor &in, Tensor *out, Context *ctx) {
 }
 
 template <typename DType, typename Lang>
-void SoftMax(const Tensor &in, Tensor *out, Context *ctx, int axis) {
+void SoftMaxBackward(const Tensor &in, Tensor *out, const Tensor &fdout,
+                     Context *ctx) {
   LOG(FATAL) << "Not Implemented";
 }
 

--- a/src/core/tensor/tensor_math_cpp.h
+++ b/src/core/tensor/tensor_math_cpp.h
@@ -240,36 +240,11 @@ void Abs<float, lang::Cpp>(const Tensor &in, Tensor *out, Context *ctx) {
 
 #ifdef USE_DNNL
 template <>
-void SoftMax<float, lang::Cpp>(const Tensor &in, Tensor *out, Context *ctx,
-                               int axis) {
-  CHECK_EQ(in.device()->lang(), kCpp);
-
-  CHECK_LE(axis, (int)in.shape().size() - 1);
-  CHECK_GE(axis, -1 * (int)in.nDim());
-
-  Shape original_shape = in.shape();
-  if (axis < 0) axis = in.shape().size() + axis;
-
-  Shape coerced_shape = {1, 1};
-  for (int i = 0; i < in.shape().size(); i++) {
-    if (i < axis)
-      coerced_shape[0] *= in.shape()[i];
-    else
-      coerced_shape[1] *= in.shape()[i];
-  }
-  Tensor in_reshaped = Reshape(in, coerced_shape);
-  out->Reshape(coerced_shape);
-
-  // optimise by minus x - x.max()
-  auto in_max = RowMax(in_reshaped);
-  in_max.Reshape({coerced_shape[0], 1});
-  in_reshaped = in_reshaped - in_max;
-
-  auto md = dnnl::memory::desc({coerced_shape[0], coerced_shape[1]},
+void SoftMax<float, lang::Cpp>(const Tensor &in, Tensor *out, Context *ctx) {
+  auto md = dnnl::memory::desc({in.shape()[0], in.shape()[1]},
                                dnnl::memory::data_type::f32,
                                dnnl::memory::format_tag::ab);
-  auto in_mem =
-      dnnl::memory(md, ctx->dnnl_engine, in_reshaped.block()->mutable_data());
+  auto in_mem = dnnl::memory(md, ctx->dnnl_engine, in.block()->mutable_data());
   auto out_mem =
       dnnl::memory(md, ctx->dnnl_engine, out->block()->mutable_data());
 
@@ -281,9 +256,35 @@ void SoftMax<float, lang::Cpp>(const Tensor &in, Tensor *out, Context *ctx,
   softmax.execute(ctx->dnnl_stream,
                   {{DNNL_ARG_SRC, in_mem}, {DNNL_ARG_DST, out_mem}});
   ctx->dnnl_stream.wait();
-
-  out->Reshape(original_shape);
 }
+
+template <>
+void SoftMaxBackward<float, lang::Cpp>(const Tensor &in, Tensor *out,
+                                       const Tensor &fdout, Context *ctx) {
+  auto md = dnnl::memory::desc({in.shape()[0], in.shape()[1]},
+                               dnnl::memory::data_type::f32,
+                               dnnl::memory::format_tag::ab);
+  auto in_mem = dnnl::memory(md, ctx->dnnl_engine, in.block()->mutable_data());
+  auto fdout_mem =
+      dnnl::memory(md, ctx->dnnl_engine, fdout.block()->mutable_data());
+  auto out_mem =
+      dnnl::memory(md, ctx->dnnl_engine, out->block()->mutable_data());
+
+  auto softmax_desc =
+      dnnl::softmax_forward::desc(dnnl::prop_kind::forward_scoring, md, 1);
+  auto softmax_prim_desc =
+      dnnl::softmax_forward::primitive_desc(softmax_desc, ctx->dnnl_engine);
+
+  auto softmaxbwd_desc = dnnl::softmax_backward::desc(md, md, 1);
+  auto softmaxbwd_prim_desc = dnnl::softmax_backward::primitive_desc(
+      softmaxbwd_desc, ctx->dnnl_engine, softmax_prim_desc);
+  auto softmaxbwd = dnnl::softmax_backward(softmaxbwd_prim_desc);
+  softmaxbwd.execute(ctx->dnnl_stream, {{DNNL_ARG_DIFF_SRC, out_mem},
+                                        {DNNL_ARG_DIFF_DST, in_mem},
+                                        {DNNL_ARG_DST, fdout_mem}});
+  ctx->dnnl_stream.wait();
+}
+
 #endif  // USE_DNNL
 
 template <>
@@ -927,6 +928,8 @@ void RowMax<float, lang::Cpp>(const Tensor &in, Tensor *out, Context *ctx) {
   }
 }
 
+// =========Matrix operations ================================================
+/*
 template <>
 void SoftMax<float, lang::Cpp>(const Tensor &in, Tensor *out, Context *ctx) {
   CHECK_LE(in.nDim(), 2u)
@@ -947,8 +950,6 @@ void SoftMax<float, lang::Cpp>(const Tensor &in, Tensor *out, Context *ctx) {
   out->Reshape(in.shape());
 }
 
-// =========Matrix operations ================================================
-/*
 template <>
 void AddCol<float, lang::Cpp>(const size_t nrow, const size_t ncol,
                               const Tensor& A, const Tensor& v, Tensor* out,

--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -340,27 +340,22 @@ class TestAPI(unittest.TestCase):
             hndl = singa_api.BatchNormHandle(
                 m_0,
                 tensor.Tensor(device=dev, data=x_0).data)
-            (y_2_c, rm_2_c, rv_2_c, bm_2_c,
-             bv_2_c) = singa_api.CpuBatchNormForwardTraining(
-                 hndl,
-                 tensor.Tensor(device=dev, data=x_0).data,
-                 tensor.Tensor(device=dev, data=s_0).data,
-                 tensor.Tensor(device=dev, data=b_0).data,
-                 tensor.Tensor(device=dev, data=rm_0).data,
-                 tensor.Tensor(device=dev, data=rv_0).data)
+            (y_2_c, bm_2_c, bv_2_c) = singa_api.CpuBatchNormForwardTraining(
+                hndl,
+                tensor.Tensor(device=dev, data=x_0).data,
+                tensor.Tensor(device=dev, data=s_0).data,
+                tensor.Tensor(device=dev, data=b_0).data,
+                tensor.Tensor(device=dev, data=rm_0).data,
+                tensor.Tensor(device=dev, data=rv_0).data)
 
             np.testing.assert_array_almost_equal(
                 y_1, tensor.to_numpy(_cTensor_to_pyTensor(y_2_c)))
-            #np.testing.assert_array_almost_equal(
-            #    bm_1, tensor.to_numpy(_cTensor_to_pyTensor(bm_2_c)))
             np.testing.assert_array_almost_equal(
-                rm_1, tensor.to_numpy(_cTensor_to_pyTensor(rm_2_c)))
+                bm_1, tensor.to_numpy(_cTensor_to_pyTensor(bm_2_c)))
             #print(bv_1)
             #print(tensor.to_numpy(_cTensor_to_pyTensor(bv_2_c)))
             #np.testing.assert_array_almost_equal(
             #    bv_1, tensor.to_numpy(_cTensor_to_pyTensor(bv_2_c)), decimal=3)
-            np.testing.assert_array_almost_equal(
-                rv_1, tensor.to_numpy(_cTensor_to_pyTensor(rv_2_c)), decimal=4)
             return
 
         x_0 = np.array([1, 1, 1, 1, 2, 2, 2, 2, 10, 10, 10, 10, 20, 20, 20, 20],


### PR DESCRIPTION
The current SoftMax backward is using numpy, which cannot be buffered.

This PR uses cudnn and dnnl SoftMaxBackward instead of numpy.
