### PR TITLE
Bugfix: cpu batchnorm (num of args does not match)

### DIFF
--- a/src/model/operation/batchnorm.cc
+++ b/src/model/operation/batchnorm.cc
@@ -177,7 +177,7 @@ const std::vector<Tensor> CpuBatchNormForwardTraining(
       {y.block(), running_mean.block(), running_var.block(), mean.block(),
        var.block()});
 
-  return {y, running_mean, running_var, mean, var};
+  return {y, mean, var};
 }
 
 const std::vector<Tensor> CpuBatchNormBackwardx(


### PR DESCRIPTION
There is an new error in cpu batchnorm, where the number of output arguments do not match with the python autograd code. This PR simply fix the issue.

```
root@b8dfa5473dea:~/dcsysh/singa/test/python# python3 test_operation.py
................................................................E............................................................
======================================================================
ERROR: test_batchnorm2d_cpu (__main__.TestPythonOperation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_operation.py", line 286, in test_batchnorm2d_cpu
    y = batchnorm_0(cpu_input_tensor)
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 1502, in __call__
    self.running_var,
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 1581, in batchnorm_2d
    return _BatchNorm2d(handle, running_mean, running_var)(x, scale, bias)[0]
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 244, in __call__
    return self._do_forward(*xs)
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 294, in _do_forward
    ys = self.forward(*xs)
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 1532, in forward
    self.running_var)
ValueError: too many values to unpack (expected 3)

----------------------------------------------------------------------
Ran 125 tests in 0.766s

FAILED (errors=1)

root@b8dfa5473dea:~/dcsysh/singa/examples/autograd# python3 resnet.py
Start intialization............
  0%|                                                                                                                                                                                  | 0/100 [00:26<?, ?it/s]
Traceback (most recent call last):
  File "resnet.py", line 278, in <module>
    x = model(tx)
  File "resnet.py", line 179, in __call__
    x = self.bn1(x)
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 1502, in __call__
    self.running_var,
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 1581, in batchnorm_2d
    return _BatchNorm2d(handle, running_mean, running_var)(x, scale, bias)[0]
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 244, in __call__
    return self._do_forward(*xs)
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 294, in _do_forward
    ys = self.forward(*xs)
  File "/root/dcsysh/singa/build/python/singa/autograd.py", line 1532, in forward
    self.running_var)
```