### PR TITLE
fix softmax nan problem

### DIFF
--- a/src/core/tensor/tensor_math_cuda.h
+++ b/src/core/tensor/tensor_math_cuda.h
@@ -938,7 +938,7 @@ void SoftMax<float, lang::Cuda>(const Tensor& in, Tensor* out, Context* ctx) {
 template <>
 void SoftMaxBackward<float, lang::Cuda>(const Tensor& in, Tensor* out,
                                         const Tensor& fdout, Context* ctx) {
-  cudnnSoftmaxAlgorithm_t algorithm = CUDNN_SOFTMAX_FAST;
+  cudnnSoftmaxAlgorithm_t algorithm = CUDNN_SOFTMAX_ACCURATE;
   cudnnSoftmaxMode_t mode = CUDNN_SOFTMAX_MODE_INSTANCE;
 
   /*

--- a/src/core/tensor/tensor_math_cuda.h
+++ b/src/core/tensor/tensor_math_cuda.h
@@ -904,7 +904,7 @@ void GEMM<float, lang::Cuda>(const float alpha, const Tensor& A,
 
 template <>
 void SoftMax<float, lang::Cuda>(const Tensor& in, Tensor* out, Context* ctx) {
-  cudnnSoftmaxAlgorithm_t algorithm = CUDNN_SOFTMAX_FAST;
+  cudnnSoftmaxAlgorithm_t algorithm = CUDNN_SOFTMAX_ACCURATE;
   cudnnSoftmaxMode_t mode = CUDNN_SOFTMAX_MODE_INSTANCE;
 
   /*


### PR DESCRIPTION
Here I change the algorithm of the cudnnSoftmaxForward function.

The original algorithm was CUDNN_SOFTMAX_FAST which may lead to overflow when the input numbers are too large. Change it to CUDNN_SOFTMAX_ACCURATE will solve this problem.

For example: If cudnn softmax is used in mlp.py, it will lead to this problem.