### PR TITLE
Fix the env path to include mpiexec

### DIFF
--- a/tool/docker/devel/ubuntu/cuda10/Dockerfile
+++ b/tool/docker/devel/ubuntu/cuda10/Dockerfile
@@ -103,7 +103,7 @@ RUN git clone https://github.com/apache/singa.git $HOME/singa \
 RUN cd $HOME/singa/build && make && make install
 ENV PYTHONPATH="/root/singa/build/python/"
 
-WORKDIR $HOME/singa
+WORKDIR /root/singa
 EXPOSE 22
 
 CMD ["/usr/sbin/sshd", "-D"]

--- a/tool/docker/devel/ubuntu/cuda10/Dockerfile
+++ b/tool/docker/devel/ubuntu/cuda10/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install -U --no-cache \
+    && pip3 install tqdm \
     wheel \
     numpy \
     setuptools \
@@ -100,6 +101,7 @@ RUN git clone https://github.com/apache/singa.git $HOME/singa \
     && mkdir build && cd build \
     && /usr/local/bin/cmake -DENABLE_TEST=ON -DUSE_CUDA=ON -DUSE_PYTHON3=ON -DUSE_DNNL=ON -DUSE_DIST=ON ..
 RUN cd $HOME/singa/build && make && make install
+ENV PYTHONPATH="/root/singa/build/python/"
 
 WORKDIR $HOME/singa
 EXPOSE 22

--- a/tool/docker/devel/ubuntu/cuda10/Dockerfile
+++ b/tool/docker/devel/ubuntu/cuda10/Dockerfile
@@ -90,9 +90,8 @@ RUN wget http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz -P $HOME
     && cd mpich-3.3.2 \
     && ./configure --prefix=$HOME/mpich-3.3.2/build --disable-fortran 2>&1 | tee c.txt \
     && make 2>&1 | tee m.txt \
-    && make install 2>&1 | tee mi.txt \
-    && PATH=$HOME/mpich-3.3.2/build/bin:$PATH \
-    && export PATH
+    && make install 2>&1 | tee mi.txt
+ENV PATH=/root/mpich-3.3.2/build/bin:$PATH
 
 # build singa
 RUN git clone https://github.com/apache/singa.git $HOME/singa \

--- a/tool/docker/devel/ubuntu/cuda9/Dockerfile
+++ b/tool/docker/devel/ubuntu/cuda9/Dockerfile
@@ -107,7 +107,7 @@ RUN git clone https://github.com/apache/singa.git $HOME/singa \
 RUN cd $HOME/singa/build && make && make install
 ENV PYTHONPATH="/root/singa/build/python/"
 
-WORKDIR $HOME/singa
+WORKDIR /root/singa
 EXPOSE 22
 
 CMD ["/usr/sbin/sshd", "-D"]

--- a/tool/docker/devel/ubuntu/cuda9/Dockerfile
+++ b/tool/docker/devel/ubuntu/cuda9/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install -U --no-cache \
+    && pip3 install tqdm \
     wheel \
     numpy \
     setuptools \
@@ -104,6 +105,7 @@ RUN git clone https://github.com/apache/singa.git $HOME/singa \
     && mkdir build && cd build \
     && cmake -DENABLE_TEST=ON -DUSE_CUDA=ON -DUSE_PYTHON3=ON -DUSE_DNNL=ON -DUSE_DIST=ON ..
 RUN cd $HOME/singa/build && make && make install
+ENV PYTHONPATH="/root/singa/build/python/"
 
 WORKDIR $HOME/singa
 EXPOSE 22

--- a/tool/docker/devel/ubuntu/cuda9/Dockerfile
+++ b/tool/docker/devel/ubuntu/cuda9/Dockerfile
@@ -94,9 +94,8 @@ RUN wget http://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz -P $HOME
     && cd mpich-3.3.2 \
     && ./configure --prefix=$HOME/mpich-3.3.2/build --disable-fortran 2>&1 | tee c.txt \
     && make 2>&1 | tee m.txt \
-    && make install 2>&1 | tee mi.txt \
-    && PATH=$HOME/mpich-3.3.2/build/bin:$PATH \
-    && export PATH
+    && make install 2>&1 | tee mi.txt
+ENV PATH=/root/mpich-3.3.2/build/bin:$PATH
 
 # build singa
 RUN git clone https://github.com/apache/singa.git $HOME/singa \


### PR DESCRIPTION
In dockerfile, this fix registers the mpiexec command in environment variable path automatically
Before this fix it needs to add the path of the mpi binary manually