### PR TITLE
Singa 507 _Conv2d and _Pooling2d support odd padding

### DIFF
--- a/python/singa/utils.py
+++ b/python/singa/utils.py
@@ -16,6 +16,11 @@
 # =============================================================================
 
 import sys
+import math
+import numpy as np
+
+from singa import tensor
+from . import singa_wrap as singa
 
 
 def update_progress(progress, info):
@@ -45,3 +50,184 @@ def update_progress(progress, info):
     sys.stdout.write(text)
     sys.stdout.write('\b' * (9 + barLength + len(status)))
     sys.stdout.flush()
+
+
+def handle_odd_pad_fwd(x, odd_padding):
+    """
+    handle odd padding mode forward
+    Args:x
+        the input tensor
+    Args:odd_padding
+        the odd_padding
+    Returns: 
+        tensor, the output
+    """
+    x_tensor = tensor.from_raw_tensor(x)
+    # (axis, left padding if True else right padding)
+    flags = [(2, True), (2, False), (3, True), (3, False)]
+    for (axis, left), pad in zip(flags, odd_padding):
+        if pad == 0:
+            continue
+        zeros_shape = list(x_tensor.data.shape())
+        zeros_shape[axis] = pad
+        zero_padding = np.zeros(zeros_shape).astype(np.float32)
+        zero_padding = tensor.Tensor(device=x.device(), data=zero_padding)
+        if left:
+            x_tensor = tensor.concatenate((zero_padding, x_tensor), axis)
+        else:
+            x_tensor = tensor.concatenate((x_tensor, zero_padding), axis)
+    return x_tensor.data
+
+
+def handle_odd_pad_bwd(dx, odd_padding):
+    """
+    handle odd padding mode backward
+    Args:dx
+        the backward tensor
+    Args:odd_padding
+        the odd_padding
+    Returns: 
+        tensor, the output
+    """
+    # (axis, left padding if True else right padding)
+    flags = [(2, True), (2, False), (3, True), (3, False)]
+    for (axis, left), pad in zip(flags, odd_padding):
+        if pad == 0:
+            continue
+        axis_shape = list(dx.shape())[axis]
+        if left:
+            dx = singa.SliceOn(dx, pad, axis_shape, axis)
+        else:
+            dx = singa.SliceOn(dx, 0, axis_shape - pad, axis)
+    return dx
+
+
+def same_pad_shape_check(handle, pad_mode, x):
+    """
+    check the shape is correct for same padding mode
+    Args:handle
+        the handle
+    Args:pad_mode
+        pad_mode
+    Args:x
+        input tensor
+    Returns: 
+        tuple, the correct padding(before divide 2)
+    """
+    _kernel = [handle.kernel_h, handle.kernel_w]
+    _stride = [handle.stride_h, handle.stride_w]
+    _padding = [handle.pad_h, handle.pad_w]
+    _padding_correct = get_padding_shape(pad_mode,
+                                         x.shape()[2:], _kernel, _stride)
+    _padding_crop, _ = [x // 2 for x in _padding_correct]
+    assert _padding == _padding_crop, (
+        'For a same mode, the given padding %s is wrong, the correct one should be %s.'
+        % (_padding, _padding_crop))
+    return _padding_correct
+
+
+def re_new_handle(handle, x, is_pool=False):
+    """
+    re-new a handle by useing the new input tensor
+    Args:handle
+        the handle
+    Args:x
+        input tensor
+    Returns: 
+        handle, a new handle
+    """
+    kernel_size = [handle.kernel_h, handle.kernel_w]
+    stride = [handle.stride_h, handle.stride_w]
+    padding = [handle.pad_h, handle.pad_w]
+    if is_pool:
+        params = (x, kernel_size, stride, padding, handle.is_max_pooling)
+    else:
+        params = (x, kernel_size, stride, padding, handle.channels,
+                  handle.num_filters, handle.bias_term, handle.group)
+    if (type(handle) == singa.ConvHandle or
+            type(handle) == singa.PoolingHandle):
+        handle = singa.PoolingHandle(*params) if is_pool else singa.ConvHandle(
+            *params)
+    else:
+        handle = singa.CudnnPoolingHandle(
+            *params) if is_pool else singa.CudnnConvHandle(*params)
+    return handle
+
+
+def get_padding_shape(pad_mode, input_spatial_shape, kernel_spatial_shape,
+                      strides_spatial):
+    """
+    return padding shape of conv2d or pooling,
+    Args:
+        pad_mode: string
+    Args:
+        kernel_spatial_shape: list[int]
+    Args:
+        strides_spatial: list[int]
+    Returns: 
+        list[int]
+    """
+    output_spatial_shape = get_output_shape(pad_mode, input_spatial_shape,
+                                            kernel_spatial_shape,
+                                            strides_spatial)
+    pad_shape = [0] * len(input_spatial_shape) * 2  # 2 means left and right
+    # the odd paddding is the value that cannot be handled by the tuple padding (w, h) mode
+    # so we need to firstly handle the input, then use the nomal padding method.
+    odd_padd_shape = [0] * len(input_spatial_shape) * 2
+    for i in range(len(input_spatial_shape)):
+        whole_pad = (output_spatial_shape[i] - 1) * strides_spatial[i] + \
+            kernel_spatial_shape[i] - input_spatial_shape[i]
+        pad_shape[2 * i] = pad_shape[2 * i + 1] = whole_pad // 2
+        if whole_pad % 2 != 0:
+            if pad_mode == "SAME_UPPER":
+                odd_padd_shape[2 * i + 1] += 1
+            else:
+                odd_padd_shape[2 * i] += 1
+    return pad_shape, odd_padd_shape
+
+
+def get_output_shape(auto_pad, input_spatial_shape, kernel_spatial_shape,
+                     strides_spatial):
+    """
+    return output shape of conv2d or pooling,
+    ! borrow from onnx
+    Args:
+        auto_pad: string
+    Args:
+        kernel_spatial_shape: list[int]
+    Args:
+        strides_spatial: list[int]
+    Args:
+        output_spatial_shape: list[int]
+    Returns: 
+        list[int
+    """
+    out_shape = [0] * len(input_spatial_shape)
+    if auto_pad in ('SAME_UPPER', 'SAME_LOWER'):
+        for i in range(len(input_spatial_shape)):
+            out_shape[i] = int(
+                np.ceil(
+                    float(input_spatial_shape[i]) / float(strides_spatial[i])))
+    elif auto_pad == 'VALID':
+        for i in range(len(input_spatial_shape)):
+            out_shape[i] = int(
+                np.ceil(
+                    float(input_spatial_shape[i] -
+                          (kernel_spatial_shape[i] - 1)) /
+                    float(strides_spatial[i])))
+    return out_shape
+
+
+def force_unicode(s):
+    """
+    return string of a bytes
+    ! borrow from onnx
+    Args:
+        s: string or bytes
+    Returns: 
+        string
+    """
+    try:
+        return s.decode('utf-8')
+    except AttributeError:
+        return s

--- a/test/python/test_operation.py
+++ b/test/python/test_operation.py
@@ -169,6 +169,132 @@ class TestPythonOperation(unittest.TestCase):
         y_without_bias = conv_without_bias_0(gpu_input_tensor)
         self.check_shape(y_without_bias.shape, (2, 1, 2, 2))
 
+    def _conv_same_pad(self, dev, pad_mode, is_2d):
+        if is_2d:
+            x_h, w_h, k_h, p_h = 32, 4, 4, 1
+            if pad_mode == "SAME_LOWER":
+                o_p = (0, 1, 0, 1)
+            else:
+                o_p = (1, 0, 1, 0)
+        else:
+            x_h, w_h, k_h, p_h = 1, 1, 1, 0
+            if pad_mode == "SAME_LOWER":
+                o_p = (0, 0, 0, 1)
+            else:
+                o_p = (0, 0, 1, 0)
+        x = tensor.Tensor(shape=(3, 3, x_h, 32), device=dev)
+        x.gaussian(0.0, 1.0)
+
+        w = tensor.Tensor(shape=(3, 3, w_h, 4), device=dev)
+        w.gaussian(0.0, 1.0)
+
+        # with the same padding, the padding should be 3
+        # for SAME_UPPER, is (1, 1) + (0, 1)
+        # for SAME_LOWER, is (1, 1) + (1, 0)
+
+        x_shape = x.shape
+        kernel = (k_h, 4)
+        padding = (p_h, 1)
+        stride = (1, 1)
+        group = 1
+        bias = False
+        in_channels = x_shape[1]
+        w_shape = w.shape
+        out_channels = w_shape[0]
+        assert w_shape[1] == in_channels // group
+
+        if dev == cpu_dev:
+            handle = singa.ConvHandle(x.data, kernel, stride, padding,
+                                      in_channels, out_channels, bias, group)
+        else:
+            handle = singa.CudnnConvHandle(x.data, kernel, stride, padding,
+                                           in_channels, out_channels, bias,
+                                           group)
+        y = autograd._Conv2d(handle, o_p)(x, w)[0]
+
+        dy = np.ones((3, 3, x_h, 32), dtype=np.float32)
+        dy = tensor.from_numpy(dy)
+        dy.to_device(dev)
+
+        dx, dW = y.creator.backward(dy.data)
+        self.check_shape(y.shape, (3, 3, x_h, 32))
+        self.check_shape(dx.shape(), (3, 3, x_h, 32))
+        self.check_shape(dW.shape(), (3, 3, w_h, 4))
+
+    def test_conv2d_same_pad_cpu(self):
+        self._conv_same_pad(cpu_dev, "SAME_LOWER", True)
+        self._conv_same_pad(cpu_dev, "SAME_UPPER", True)
+
+    def test_conv2d_same_pad_gpu(self):
+        self._conv_same_pad(gpu_dev, "SAME_LOWER", True)
+        self._conv_same_pad(gpu_dev, "SAME_UPPER", True)
+
+    def test_conv1d_same_pad_cpu(self):
+        self._conv_same_pad(cpu_dev, "SAME_LOWER", False)
+        self._conv_same_pad(cpu_dev, "SAME_UPPER", False)
+
+    def test_conv1d_same_pad_gpu(self):
+        self._conv_same_pad(gpu_dev, "SAME_LOWER", False)
+        self._conv_same_pad(gpu_dev, "SAME_UPPER", False)
+
+    def _pooling_same_pad(self, dev, pad_mode, is_2d):
+        if is_2d:
+            x_h, k_h, p_h = 32, 4, 1
+            if pad_mode == "SAME_LOWER":
+                o_p = (0, 1, 0, 1)
+            else:
+                o_p = (1, 0, 1, 0)
+        else:
+            x_h, k_h, p_h = 1, 1, 0
+            if pad_mode == "SAME_LOWER":
+                o_p = (0, 0, 0, 1)
+            else:
+                o_p = (0, 0, 1, 0)
+        x = tensor.Tensor(shape=(3, 3, x_h, 32), device=dev)
+        x.gaussian(0.0, 1.0)
+
+        # with the same padding, the padding should be 3
+        # for SAME_UPPER, is (1, 1) + (0, 1)
+        # for SAME_LOWER, is (1, 1) + (1, 0)
+
+        x_shape = x.shape
+        kernel = (k_h, 4)
+        # we add 4 padding here and hope the conv and trim one padding then
+        padding = (p_h, 1)
+        stride = (1, 1)
+
+        if dev == cpu_dev:
+            handle = singa.PoolingHandle(x.data, kernel, stride, padding, True)
+        else:
+            handle = singa.CudnnPoolingHandle(x.data, kernel, stride, padding,
+                                              True)
+
+        y = autograd._Pooling2d(handle, o_p)(x)[0]
+
+        dy = np.ones((3, 3, x_h, 32), dtype=np.float32)
+        dy = tensor.from_numpy(dy)
+        dy.to_device(dev)
+
+        dx = y.creator.backward(dy.data)
+        self.check_shape(y.shape, (3, 3, x_h, 32))
+        self.check_shape(dx.shape(), (3, 3, x_h, 32))
+
+    def test_pooling2d_same_pad_cpu(self):
+        self._pooling_same_pad(cpu_dev, "SAME_LOWER", True)
+        self._pooling_same_pad(cpu_dev, "SAME_UPPER", True)
+
+    def test_pooling2d_same_pad_gpu(self):
+        self._pooling_same_pad(gpu_dev, "SAME_LOWER", True)
+        self._pooling_same_pad(gpu_dev, "SAME_UPPER", True)
+
+    def test_pooling1d_same_pad_cpu(self):
+        self._pooling_same_pad(cpu_dev, "SAME_LOWER", False)
+        self._pooling_same_pad(cpu_dev, "SAME_UPPER", False)
+
+    def test_pooling1d_same_pad_gpu(self):
+        self._pooling_same_pad(gpu_dev, "SAME_LOWER", False)
+        self._pooling_same_pad(gpu_dev, "SAME_UPPER", False)
+
     def test_sum_cpu(self):
         x = np.array([0.1, -1.0, 0.4, 4.0, -0.9,
                       9.0]).reshape(3, 2).astype(np.float32)


### PR DESCRIPTION
Since onnx requests same padding mode, we need to optimize conv and pooling these 2 operators.

FYI:

> auto_pad must be either NOTSET, SAME_UPPER, SAME_LOWER or VALID. Where default value is NOTSET, which means explicit padding is used. SAME_UPPER or SAME_LOWER mean pad the input so that the output spatial size match the input.In case of odd number add the extra padding at the end for SAME_UPPER and at the beginning for SAME_LOWER. VALID mean no padding.

This JR will finish:

- lower-level ops(_Conv2d and _Pooling2d) support odd padding mode, for example, if padding is [2,5,2,5], it will crop to a normal padding with [2,2,2,2], and a odd padding with [0,3,0,3]. The odd padding will be added to x tensor firstly and then do normal process with normal padding, then in the backward, the odd padding will be cropped.
- upper-level ops support four bins padding(i.e., (1,2,1,2,)) and also SAME_UPPER, SAME_LOWER for both 2d and 1d input.
- For SAME_UPPER, SAME_LOWER, can do shape checking, and if not set shape, can compute the correct shape.
- Test cases.