### PR TITLE
SINGA-415 add asf.yaml file

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+github:
+  description: a distributed deep learning platform
+  labels:
+    - deep-learning


### PR DESCRIPTION
The Apache infrastructe supports [new features for git](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=127405038) with .asf.yaml file. 

In this pull request, we improve the description and labels of SINGA github. 

Labels are important because they allow github users to navigate and explore github repositores with [Topics](https://github.com/topics). I added one topic "deep learning", but we may add also other related topics such as python3, docker, cpp, rest-api, machine-learning, ... etc.

An example for .asf.yaml in Apache ShardingSphere is [here](https://github.com/apache/incubator-shardingsphere/blob/master/.asf.yaml).

The .asf.yaml can be added also to [singa-site](https://github.com/apache/singa-site) to enable the new features for site deployment.

