### PR TITLE
SINGA-415 Enable github wiki

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,3 +19,6 @@ github:
   description: a distributed deep learning platform
   labels:
     - deep-learning
+  features:
+    # Enable wiki for documentation
+    wiki: true


### PR DESCRIPTION
@nudles , I remember that you wanted to enable github wiki as discussed [here](https://issues.apache.org/jira/browse/SINGA-405?focusedCommentId=16699087&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16699087). We can now have github wiki by adding the following in the asf.yaml file.