### PR TITLE
Improve graph compatibility

### DIFF
--- a/python/singa/device.py
+++ b/python/singa/device.py
@@ -97,14 +97,17 @@ def create_cuda_gpus(num):
     return singa.Platform.CreateCudaGPUs(num)
 
 
-def create_cuda_gpu():
+def create_cuda_gpu(set_default=True):
     '''Create a single CudaGPU device.
 
     Returns:
         a swig converted CudaGPU device.
     '''
     assert singa.USE_CUDA, 'SINGA has not been compiled with CUDA enabled.'
-    return singa.Platform.CreateCudaGPUs(1)[0]
+    devices = singa.Platform.CreateCudaGPUs(1)
+    if set_default is True:
+        set_default_device(devices[0])
+    return devices[0]
 
 
 def create_cuda_gpus_on(device_ids):

--- a/src/core/tensor/tensor.cc
+++ b/src/core/tensor/tensor.cc
@@ -514,7 +514,8 @@ Tensor &Tensor::operator=(Tensor &&in) {
 
 #define GenUnaryTensorArgMemberFn(op, fn) \
   Tensor &Tensor::op(const Tensor &in) {  \
-    fn(*this, in, this);                  \
+    Tensor out(*this);                    \
+    fn(*this, in, &out);                  \
     return *this;                         \
   }
 
@@ -526,7 +527,8 @@ GenUnaryTensorArgMemberFn(operator/=, Div);
 #define GenUnaryScalarArgMemberFn(op, fn) \
   template <typename DType>               \
   Tensor &Tensor::op(const DType x) {     \
-    fn(*this, x, this);                   \
+    Tensor out(*this);                    \
+    fn(*this, x, &out);                   \
     return *this;                         \
   }                                       \
   template Tensor &Tensor::op<float>(const float x)
@@ -1466,7 +1468,7 @@ template <typename SType>
 void Mult(const SType alpha, const Tensor &A, const Tensor &B, const SType beta,
           Tensor *C) {
   vector<Block *> read_blocks = {A.block(), B.block()};
-  if (beta) read_blocks.push_back(C->block());
+  // if (beta) read_blocks.push_back(C->block());
   if (B.nDim() == 1u) {
     CHECK_EQ(A.shape().size(), 2u);
     TYPE_LANG_SWITCH(A.data_type(), DType, A.device()->lang(), Lang, {

--- a/src/model/operation/batchnorm.cc
+++ b/src/model/operation/batchnorm.cc
@@ -84,7 +84,7 @@ Tensor CpuBatchNormForwardInference(const BatchNormHandle& bnh, const Tensor& x,
   Tensor w = get_bn_weight_from(bnScale, bnBias);
 
   y.device()->Exec(
-      [y, w, &x, &running_mean, &running_var, &bnh](Context* ctx) mutable {
+      [y, w, x, &running_mean, &running_var, &bnh](Context* ctx) mutable {
         auto eng = ctx->dnnl_engine;
         using namespace dnnl;
 
@@ -138,7 +138,7 @@ const std::vector<Tensor> CpuBatchNormForwardTraining(
   Tensor w = get_bn_weight_from(bnScale, bnBias);
 
   y.device()->Exec(
-      [y, mean, var, w, &x, &running_mean, &running_var,
+      [y, mean, var, w, x, &running_mean, &running_var,
        &bnh](Context* ctx) mutable {
         auto eng = ctx->dnnl_engine;
         using namespace dnnl;
@@ -202,7 +202,7 @@ const std::vector<Tensor> CpuBatchNormBackwardx(
   dw.ResetLike(w);
 
   dx.device()->Exec(
-      [w, dw, dx, dy, &x, &y, &mean, &var, &bnh](Context* ctx) mutable {
+      [w, dw, dx, dy, x, y, mean, var, &bnh](Context* ctx) mutable {
         auto eng = ctx->dnnl_engine;
         using namespace dnnl;
 
@@ -307,7 +307,7 @@ const std::vector<Tensor> GpuBatchNormForwardTraining(
   output.ResetLike(x);
 
   output.device()->Exec(
-      [&, mean, var, input, output](Context* ctx) mutable {
+      [&, input, output, mean, var, x](Context* ctx) mutable {
         const float alpha = 1.0f, beta = 0.0f;
         double epsilon = CUDNN_BN_MIN_EPSILON;
         CUDNN_CHECK(cudnnBatchNormalizationForwardTraining(
@@ -382,7 +382,7 @@ const std::vector<Tensor> GpuBatchNormBackward(
   dbnBias.ResetLike(bnScale);
 
   dx.device()->Exec(
-      [&, dy, dx, dbnScale, dbnBias](Context* ctx) mutable {
+      [&, x, dy, dx, dbnScale, dbnBias, mean, var](Context* ctx) mutable {
         const float alpha = 1.0f, beta = .0f;
         double epsilon = CUDNN_BN_MIN_EPSILON;
         CUDNN_CHECK(cudnnBatchNormalizationBackward(

--- a/src/model/operation/batchnorm.cc
+++ b/src/model/operation/batchnorm.cc
@@ -307,7 +307,7 @@ const std::vector<Tensor> GpuBatchNormForwardTraining(
   output.ResetLike(x);
 
   output.device()->Exec(
-      [&, input, output, mean, var, x](Context* ctx) mutable {
+      [=, &cbnh](Context* ctx) mutable {
         const float alpha = 1.0f, beta = 0.0f;
         double epsilon = CUDNN_BN_MIN_EPSILON;
         CUDNN_CHECK(cudnnBatchNormalizationForwardTraining(
@@ -346,7 +346,7 @@ Tensor GpuBatchNormForwardInference(const CudnnBatchNormHandle& cbnh,
   Tensor output;
   output.ResetLike(x);
   output.device()->Exec(
-      [&, input, output](Context* ctx) mutable {
+      [=, &cbnh](Context* ctx) mutable {
         const float alpha = 1.0f, beta = 0.0f;
         double epsilon = CUDNN_BN_MIN_EPSILON;
         CUDNN_CHECK(cudnnBatchNormalizationForwardInference(
@@ -382,7 +382,7 @@ const std::vector<Tensor> GpuBatchNormBackward(
   dbnBias.ResetLike(bnScale);
 
   dx.device()->Exec(
-      [&, x, dy, dx, dbnScale, dbnBias, mean, var](Context* ctx) mutable {
+      [=, &cbnh](Context* ctx) mutable {
         const float alpha = 1.0f, beta = .0f;
         double epsilon = CUDNN_BN_MIN_EPSILON;
         CUDNN_CHECK(cudnnBatchNormalizationBackward(

--- a/src/model/operation/convolution.cc
+++ b/src/model/operation/convolution.cc
@@ -113,7 +113,7 @@ Tensor CpuConvForward(const Tensor &x, Tensor &W, Tensor &b,
   Tensor output(shape, dev, dtype);
 
   output.device()->Exec(
-      [output, &x, &W, &b, &ch](Context *ctx) mutable {
+      [output, x, &W, &b, &ch](Context *ctx) mutable {
         using namespace dnnl;
         using tag = memory::format_tag;
         auto eng = ctx->dnnl_engine;
@@ -241,7 +241,7 @@ Tensor CpuConvBackwardx(const Tensor &dy, Tensor &W, const Tensor &x,
   dx.ResetLike(x);
 
   dy.device()->Exec(
-      [dx, dy, &x, &W, &ch](Context *ctx) mutable {
+      [dx, dy, x, &W, &ch](Context *ctx) mutable {
         using namespace dnnl;
         auto eng = ctx->dnnl_engine;
         auto s = ctx->dnnl_stream;
@@ -325,7 +325,7 @@ Tensor CpuConvBackwardW(const Tensor &dy, const Tensor &x, const Tensor &W,
   dW.ResetLike(W);
 
   dy.device()->Exec(
-      [dy, dW, &x, &ch](Context *ctx) mutable {
+      [dy, dW, x, &ch](Context *ctx) mutable {
         using namespace dnnl;
         auto eng = ctx->dnnl_engine;
         auto s = ctx->dnnl_stream;
@@ -587,7 +587,7 @@ Tensor GpuConvForward(const Tensor &x, const Tensor &W, const Tensor &b,
   Tensor output(shape, dev, dtype);
 
   output.device()->Exec(
-      [output, &x, &W, &cch](Context *ctx) mutable {
+      [output, x, &W, &cch](Context *ctx) mutable {
         Block *inblock = x.block(), *outblock = output.block(),
               *wblock = W.block();
         float alpha = 1.f, beta = 0.f;
@@ -646,7 +646,7 @@ Tensor GpuConvBackwardW(const Tensor &dy, const Tensor &x, const Tensor &W,
   dW.ResetLike(W);
 
   dy.device()->Exec(
-      [dW, dy, &x, &cch](Context *ctx) {
+      [dW, dy, x, &cch](Context *ctx) {
         Block *inblock = x.block(), *dyblock = dy.block(),
               *dwblock = dW.block();
         float alpha = 1.f, beta = 0.f;

--- a/src/model/operation/pooling.cc
+++ b/src/model/operation/pooling.cc
@@ -99,7 +99,7 @@ Tensor CpuPoolingForward(const PoolingHandle &ph, const Tensor &x) {
            x.device(), x.data_type());
 
   y.device()->Exec(
-      [y, &x, &ph](Context *ctx) mutable {
+      [y, x, &ph](Context *ctx) mutable {
         auto eng = ctx->dnnl_engine;
         using namespace dnnl;
 
@@ -126,7 +126,7 @@ Tensor CpuPoolingBackward(const PoolingHandle &ph, const Tensor &grad,
   in_grad.ResetLike(x);
 
   in_grad.device()->Exec(
-      [in_grad, grad, &ph](Context *ctx) mutable {
+      [x, y, in_grad, grad, &ph](Context *ctx) mutable {
         auto eng = ctx->dnnl_engine;
         using namespace dnnl;
 
@@ -193,7 +193,7 @@ Tensor GpuPoolingForward(const CudnnPoolingHandle &cph, const Tensor &x) {
       x.device(), x.data_type());
 
   output.device()->Exec(
-      [output, &x, &cph](Context *ctx) mutable {
+      [output, x, &cph](Context *ctx) mutable {
         float alpha = 1.0f, beta = 0.0f;
         cudnnPoolingForward(ctx->cudnn_handle, cph.pool_desc, &alpha,
                             cph.x_desc, x.block()->data(), &beta, cph.y_desc,
@@ -213,7 +213,7 @@ Tensor GpuPoolingBackward(const CudnnPoolingHandle &cph, const Tensor &dy,
   dx.ResetLike(x);
 
   dx.device()->Exec(
-      [dx, dy, &x, &y, &cph](Context *ctx) mutable {
+      [dx, dy, x, y, &cph](Context *ctx) mutable {
         float alpha = 1.0f, beta = 0.0f;
         cudnnPoolingBackward(ctx->cudnn_handle, cph.pool_desc, &alpha,
                              cph.y_desc, y.block()->data(), cph.y_desc,


### PR DESCRIPTION
Capture some tensors by value. These tensors will be recycled during the evaluation phase. But this PR may affect memory usage when enabling graph.
