### PR TITLE
ONNX supports module

### DIFF
--- a/examples/cnn/onnx/models.json
+++ b/examples/cnn/onnx/models.json
@@ -1,0 +1,67 @@
+{
+    "mobilenet": {
+        "name": "MobileNet v2-1.0",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/mobilenet/mobilenetv2-1.0/mobilenetv2-1.0.tar.gz",
+        "path": "mobilenetv2-1.0/mobilenetv2-1.0.onnx"
+    },
+    "resnet18v1": {
+        "name": "ResNet-18 Version 1",
+        "description": "ResNet v1 uses post-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet18v1/resnet18v1.tar.gz",
+        "path": "resnet18v1/resnet18v1.onnx"
+    },
+    "resnet34v1": {
+        "name": "ResNet-34 Version 1",
+        "description": "ResNet v1 uses post-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet34v1/resnet34v1.tar.gz",
+        "path": "resnet34v1/resnet34v1.onnx"
+    },
+    "resnet50v1": {
+        "name": "ResNet-50 Version 1",
+        "description": "ResNet v1 uses post-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet50v1/resnet50v1.tar.gz",
+        "path": "resnet50v1/resnet50v1.onnx"
+    },
+    "resnet101v1": {
+        "name": "ResNet-101 Version 1",
+        "description": "ResNet v1 uses post-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet101v1/resnet101v1.tar.gz",
+        "path": "resnet101v1/resnet101v1.onnx"
+    },
+    "resnet152v1": {
+        "name": "ResNet-152 Version 1",
+        "description": "ResNet v1 uses post-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet152v1/resnet152v1.tar.gz",
+        "path": "resnet152v1/resnet152v1.onnx"
+    },
+    "resnet18v2": {
+        "name": "ResNet-18 Version 2",
+        "description": "ResNet v2 uses pre-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet18v2/resnet18v2.tar.gz",
+        "path": "resnet18v2/resnet18v2.onnx"
+    },
+    "resnet34v2": {
+        "name": "ResNet-34 Version 2",
+        "description": "ResNet v2 uses pre-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet34v2/resnet34v2.tar.gz",
+        "path": "resnet34v2/resnet34v2.onnx"
+    },
+    "resnet50v2": {
+        "name": "ResNet-50 Version 2",
+        "description": "ResNet v2 uses pre-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet50v2/resnet50v2.tar.gz",
+        "path": "resnet50v2/resnet50v2.onnx"
+    },
+    "resnet101v2": {
+        "name": "ResNet-101 Version 2",
+        "description": "ResNet v2 uses pre-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet101v2/resnet101v2.tar.gz",
+        "path": "resnet101v2/resnet101v2.onnx"
+    },
+    "resnet152v2": {
+        "name": "ResNet-152 Version 2",
+        "description": "ResNet v2 uses pre-activation for the residual blocks",
+        "url": "https://s3.amazonaws.com/onnx-model-zoo/resnet/resnet152v2/resnet152v2.tar.gz",
+        "path": "resnet152v2/resnet152v2.onnx"
+    }
+}

--- a/examples/cnn/onnx/train.py
+++ b/examples/cnn/onnx/train.py
@@ -227,8 +227,11 @@ def run(global_rank,
                   flush=True)
 
         # Evaluation Phase
+        if global_rank == 0:
+            print('Starting evaluation:')
+
         model.eval()
-        for b in range(num_val_batch):
+        for b in tqdm(range(num_val_batch)):
             x = val_x[b * batch_size:(b + 1) * batch_size]
             if model.dimension == 4:
                 if (image_size != model.input_size):
@@ -272,7 +275,7 @@ if __name__ == '__main__':
                         dest='max_epoch')
     parser.add_argument('--bs',
                         '--batch-size',
-                        default=64,
+                        default=32,
                         type=int,
                         help='batch size',
                         dest='batch_size')

--- a/examples/cnn/onnx/train.py
+++ b/examples/cnn/onnx/train.py
@@ -1,0 +1,303 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import sys, os
+import json
+from singa import singa_wrap as singa
+from singa import opt
+from singa import device
+from singa import tensor
+from singa import sonnx
+import numpy as np
+import time
+import argparse
+from PIL import Image
+import onnx
+from tqdm import tqdm
+from utils import download_model, update_batch_size, check_exist_or_download, softmax_loss
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
+sys.path.append(os.path.dirname(__file__) + '/..')
+
+# Data Augmentation
+def augmentation(x, batch_size):
+    xpad = np.pad(x, [[0, 0], [0, 0], [4, 4], [4, 4]], 'symmetric')
+    for data_num in range(0, batch_size):
+        offset = np.random.randint(8, size=2)
+        x[data_num, :, :, :] = xpad[data_num, :,
+                                    offset[0]:offset[0] + x.shape[2],
+                                    offset[1]:offset[1] + x.shape[2]]
+        if_flip = np.random.randint(2)
+        if (if_flip):
+            x[data_num, :, :, :] = x[data_num, :, :, ::-1]
+    return x
+
+
+# Calculate Accuracy
+def accuracy(pred, target):
+    # y is network output to be compared with ground truth (int)
+    y = np.argmax(pred, axis=1)
+    a = y == target
+    correct = np.array(a, "int").sum()
+    # print(correct)
+    return correct
+
+
+# Data partition according to the rank
+def partition(global_rank, world_size, train_x, train_y, val_x, val_y):
+    # Partition training data
+    data_per_rank = train_x.shape[0] // world_size
+    idx_start = global_rank * data_per_rank
+    idx_end = (global_rank + 1) * data_per_rank
+    train_x = train_x[idx_start:idx_end]
+    train_y = train_y[idx_start:idx_end]
+    # Partition evaluation data
+    data_per_rank = val_x.shape[0] // world_size
+    idx_start = global_rank * data_per_rank
+    idx_end = (global_rank + 1) * data_per_rank
+    val_x = val_x[idx_start:idx_end]
+    val_y = val_y[idx_start:idx_end]
+    return train_x, train_y, val_x, val_y
+
+
+# Function to all reduce NUMPY Accuracy and Loss from Multiple Devices
+def reduce_variable(variable, dist_opt, reducer):
+    reducer.copy_from_numpy(variable)
+    dist_opt.all_reduce(reducer.data)
+    dist_opt.wait()
+    output = tensor.to_numpy(reducer)
+    return output
+
+
+def resize_dataset(x, image_size):
+    num_data = x.shape[0]
+    dim = x.shape[1]
+    X = np.zeros(shape=(num_data, dim, image_size, image_size),
+                 dtype=np.float32)
+    for n in range(0, num_data):
+        for d in range(0, dim):
+            X[n, d, :, :] = np.array(Image.fromarray(x[n, d, :, :]).resize(
+                (image_size, image_size), Image.BILINEAR),
+                                     dtype=np.float32)
+    return X
+
+
+def run(global_rank,
+        world_size,
+        local_rank,
+        max_epoch,
+        batch_size,
+        model,
+        data,
+        sgd,
+        graph,
+        dist_option='fp32',
+        spars=None):
+    dev = device.create_cuda_gpu_on(local_rank)
+    dev.SetRandSeed(0)
+    np.random.seed(0)
+
+    if data == 'cifar10':
+        from data import cifar10
+        train_x, train_y, val_x, val_y = cifar10.load()
+    elif data == 'cifar100':
+        from data import cifar100
+        train_x, train_y, val_x, val_y = cifar100.load()
+    elif data == 'mnist':
+        from data import mnist
+        train_x, train_y, val_x, val_y = mnist.load()
+
+    num_channels = train_x.shape[1]
+    image_size = train_x.shape[2]
+    data_size = np.prod(train_x.shape[1:train_x.ndim]).item()
+    num_classes = (np.max(train_y) + 1).item()
+
+    # print content
+    with open(os.path.join(os.path.dirname(__file__), 'models.json')) as json_file:
+        model_config = json.load(json_file)
+        model_config = model_config[model]
+
+    download_model(model_config['url'])
+    onnx_model = onnx.load(os.path.join('/tmp', model_config['path']))
+    onnx_model = update_batch_size(onnx_model, batch_size)
+    sg_ir = sonnx.prepare(onnx_model, device=dev)
+    model = sonnx.create_model(sg_ir, softmax_loss, sgd)
+    model.input_size = model.input_shape[2].dim_value
+
+
+    # For distributed training, sequential gives better performance
+    # if hasattr(sgd, "communicator"):
+    DIST = False
+    sequential = True
+    # else:
+        # DIST = False
+        # sequential = False
+
+    if DIST:
+        train_x, train_y, val_x, val_y = partition(global_rank, world_size,
+                                                   train_x, train_y, val_x,
+                                                   val_y)
+    '''
+    # check dataset shape correctness
+    if global_rank == 0:
+        print("Check the shape of dataset:")
+        print(train_x.shape)
+        print(train_y.shape)
+    '''
+
+    if model.dimension == 4:
+        tx = tensor.Tensor(
+            (batch_size, num_channels, model.input_size, model.input_size), dev,
+            tensor.float32)
+    elif model.dimension == 2:
+        tx = tensor.Tensor((batch_size, data_size), dev, tensor.float32)
+        np.reshape(train_x, (train_x.shape[0], -1))
+        np.reshape(val_x, (val_x.shape[0], -1))
+
+    ty = tensor.Tensor((batch_size,), dev, tensor.int32)
+    num_train_batch = train_x.shape[0] // batch_size
+    num_val_batch = val_x.shape[0] // batch_size
+    idx = np.arange(train_x.shape[0], dtype=np.int32)
+
+    # attached model to graph
+    model.on_device(dev)
+    model.graph(graph, sequential)
+
+    # Training and Evaluation Loop
+    for epoch in range(max_epoch):
+        start_time = time.time()
+        np.random.shuffle(idx)
+
+        if global_rank == 0:
+            print('Starting Epoch {} / {}:' .format(epoch, max_epoch))
+
+        # Training Phase
+        train_correct = np.zeros(shape=[1], dtype=np.float32)
+        test_correct = np.zeros(shape=[1], dtype=np.float32)
+        train_loss = np.zeros(shape=[1], dtype=np.float32)
+
+        model.train()
+        for b in tqdm(range(num_train_batch)):
+            # Generate the patch data in this iteration
+            x = train_x[idx[b * batch_size:(b + 1) * batch_size]]
+            if model.dimension == 4:
+                x = augmentation(x, batch_size)
+                if (image_size != model.input_size):
+                    x = resize_dataset(x, model.input_size)
+            y = train_y[idx[b * batch_size:(b + 1) * batch_size]]
+
+            # Copy the patch data into input tensors
+            tx.copy_from_numpy(x)
+            ty.copy_from_numpy(y)
+
+            # Train the model
+            out = model(tx)[0]
+            loss = model.loss(out, ty)[0]
+            model.optim(loss, dist_option, spars)
+            train_correct += accuracy(tensor.to_numpy(out), y)
+            train_loss += tensor.to_numpy(loss)[0]
+
+        if DIST:
+            # Reduce the Evaluation Accuracy and Loss from Multiple Devices
+            reducer = tensor.Tensor((1,), dev, tensor.float32)
+            train_correct = reduce_variable(train_correct, sgd, reducer)
+            train_loss = reduce_variable(train_loss, sgd, reducer)
+
+        if global_rank == 0:
+            print('Training loss = %f, training accuracy = %f' %
+                  (train_loss, train_correct /
+                   (num_train_batch * batch_size * world_size)),
+                  flush=True)
+
+        # Evaluation Phase
+        model.eval()
+        for b in range(num_val_batch):
+            x = val_x[b * batch_size:(b + 1) * batch_size]
+            if model.dimension == 4:
+                if (image_size != model.input_size):
+                    x = resize_dataset(x, model.input_size)
+            y = val_y[b * batch_size:(b + 1) * batch_size]
+            tx.copy_from_numpy(x)
+            ty.copy_from_numpy(y)
+            out_test = model(tx)[0]
+            test_correct += accuracy(tensor.to_numpy(out_test), y)
+
+        if DIST:
+            # Reduce the Evaulation Accuracy from Multiple Devices
+            test_correct = reduce_variable(test_correct, sgd, reducer)
+
+        # Output the Evaluation Accuracy
+        if global_rank == 0:
+            print('Evaluation accuracy = %f, Elapsed Time = %fs' %
+                  (test_correct / (num_val_batch * batch_size * world_size),
+                   time.time() - start_time),
+                  flush=True)
+
+def loss(out, y):
+    return autograd.softmax_cross_entropy(out, y)
+
+if __name__ == '__main__':
+    # use argparse to get command config: max_epoch, model, data, etc. for single gpu training
+    parser = argparse.ArgumentParser(
+        description='Training using the autograd and graph.')
+    parser.add_argument('--model',
+                        choices=['mobilenet', 'resnet18v1', 'resnet34v1', 'resnet50v1', 'resnet101v1', 'resnet152v1', 'resnet18v2', 'resnet34v2', 'resnet50v2', 'resnet101v2', 'resnet152v2'],
+                        help='please refer to the models.json for more details',
+                        default='mobilenet')
+    parser.add_argument('--data',
+                        choices=['cifar10', 'cifar100'],
+                        default='cifar10')
+    parser.add_argument('--epoch',
+                        '--max-epoch',
+                        default=10,
+                        type=int,
+                        help='maximum epochs',
+                        dest='max_epoch')
+    parser.add_argument('--bs',
+                        '--batch-size',
+                        default=64,
+                        type=int,
+                        help='batch size',
+                        dest='batch_size')
+    parser.add_argument('--lr',
+                        '--learning-rate',
+                        default=0.005,
+                        type=float,
+                        help='initial learning rate',
+                        dest='lr')
+    # determine which gpu to use
+    parser.add_argument('--id',
+                        '--device-id',
+                        default=0,
+                        type=int,
+                        help='which GPU to use',
+                        dest='device_id')
+    parser.add_argument('--no-graph',
+                        '--disable-graph',
+                        default='True',
+                        action='store_false',
+                        help='disable graph',
+                        dest='graph')
+
+    args = parser.parse_args()
+
+    sgd = opt.SGD(lr=args.lr, momentum=0.9, weight_decay=1e-5)
+    run(0, 1, args.device_id, args.max_epoch, args.batch_size, args.model,
+        args.data, sgd, args.graph)

--- a/examples/cnn/onnx/utils.py
+++ b/examples/cnn/onnx/utils.py
@@ -1,0 +1,77 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under th
+
+import os
+import urllib.request
+import tarfile
+import glob
+import onnx
+from onnx import numpy_helper
+from singa import autograd
+import logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)-15s %(message)s')
+
+
+def download_model(url):
+    download_dir = '/tmp/'
+    with tarfile.open(check_exist_or_download(url), 'r') as t:
+        t.extractall(path=download_dir)
+
+
+def load_dataset(test_data_dir):
+    # load inputs
+    inputs = []
+    inputs_num = len(glob.glob(os.path.join(test_data_dir, 'input_*.pb')))
+    for i in range(inputs_num):
+        input_file = os.path.join(test_data_dir, 'input_{}.pb'.format(i))
+        onnx_tensor = onnx.TensorProto()
+        with open(input_file, 'rb') as f:
+            onnx_tensor.ParseFromString(f.read())
+        inputs.append(numpy_helper.to_array(onnx_tensor))
+
+    # load reference outputs
+    ref_outputs = []
+    ref_outputs_num = len(glob.glob(os.path.join(test_data_dir, 'output_*.pb')))
+    for i in range(ref_outputs_num):
+        output_file = os.path.join(test_data_dir, 'output_{}.pb'.format(i))
+        onnx_tensor = onnx.TensorProto()
+        with open(output_file, 'rb') as f:
+            onnx_tensor.ParseFromString(f.read())
+        ref_outputs.append(numpy_helper.to_array(onnx_tensor))
+    return inputs, ref_outputs
+
+
+def check_exist_or_download(url):
+    download_dir = '/tmp/'
+    name = url.rsplit('/', 1)[-1]
+    filename = os.path.join(download_dir, name)
+    if not os.path.isfile(filename):
+        logging.info("Downloading %s" % url)
+        urllib.request.urlretrieve(url, filename)
+    return filename
+
+
+def update_batch_size(onnx_model, batch_size):
+    model_input = onnx_model.graph.input[0]
+    model_input.type.tensor_type.shape.dim[0].dim_value = batch_size
+    model_output = onnx_model.graph.output[0]
+    model_output.type.tensor_type.shape.dim[0].dim_value = batch_size
+    return onnx_model
+
+def softmax_loss(out, ty):
+    return autograd.softmax_cross_entropy(out, ty)

--- a/python/singa/autograd.py
+++ b/python/singa/autograd.py
@@ -1892,15 +1892,10 @@ class BatchNorm2d(Layer):
         self.device_check(x, self.scale, self.bias, self.running_mean,
                           self.running_var)
 
-        if x.device.id() == -1:
-            if not hasattr(self, "handle"):
+        if not hasattr(self, "handle"):
+            if x.device.id() == -1:
                 self.handle = singa.BatchNormHandle(self.momentum, x.data)
-            elif x.shape[0] != self.handle.batchsize:
-                self.handle = singa.BatchNormHandle(self.momentum, x.data)
-        else:
-            if not hasattr(self, "handle"):
-                self.handle = singa.CudnnBatchNormHandle(self.momentum, x.data)
-            elif x.shape[0] != self.handle.batchsize:
+            else:
                 self.handle = singa.CudnnBatchNormHandle(self.momentum, x.data)
 
         y = batchnorm_2d(

--- a/python/singa/module.py
+++ b/python/singa/module.py
@@ -48,7 +48,10 @@ class Graph(type):
                     # deconstruct Operations before running the entire graph
                     if name == 'optim':
                         for fname in self._results:
-                            self._results[fname].creator = None
+                            if not isinstance(self._results[fname], list):
+                                self._results[fname] = [self._results[fname]]
+                            for _matrix in self._results[fname]:
+                                _matrix.creator = None
                         # make sure all Operations are deallocated
                         gc.collect()
                     # add result tensor

--- a/python/singa/sonnx.py
+++ b/python/singa/sonnx.py
@@ -2094,7 +2094,7 @@ class BaseModel(module.Module):
         """
         super(BaseModel, self).__init__()
         self.optimizer = optimizer
-        self.loss = loss
+        self.ls = loss
         self.g = sg_ir.model.graph
         self.tm = sg_ir.tensor_map
         self.oq = sg_ir.singa_ops
@@ -2126,7 +2126,7 @@ class BaseModel(module.Module):
         return [self.tm[outp] for outp in final_outputs]
 
     def loss(self, out, ty):
-        return self.loss(out, ty)
+        return self.ls(out, ty)
 
     def optim(self, loss, dist_option, spars):
         if dist_option == 'fp32':

--- a/python/singa/sonnx.py
+++ b/python/singa/sonnx.py
@@ -30,6 +30,7 @@ import warnings
 from . import singa_wrap as singa
 from . import autograd
 from . import tensor
+from . import module
 from singa import utils
 
 import collections
@@ -1144,7 +1145,7 @@ class SingaBackend(Backend):
         value = tensor.to_numpy(inputs.pop(1))
         onnx_node.consumed_inputs.extend(onnx_node.inputs[1:])
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(axis, depth, value)
 
     @classmethod
@@ -1177,7 +1178,7 @@ class SingaBackend(Backend):
         to = map_dict[to]
         assert to != None, "not support cast type: {}".format(to)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(to)
 
     @classmethod
@@ -1199,7 +1200,7 @@ class SingaBackend(Backend):
         repeats = tensor.to_numpy(inputs.pop(1)).astype(np.int32).tolist()
         onnx_node.consumed_inputs.append(onnx_node.inputs[1])
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(repeats)
 
     @classmethod
@@ -1221,7 +1222,7 @@ class SingaBackend(Backend):
         indices = tensor.to_numpy(inputs.pop(1)).astype(np.int32).tolist()
         onnx_node.consumed_inputs.append(onnx_node.inputs[1])
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(axis, indices)
 
     @classmethod
@@ -1241,7 +1242,7 @@ class SingaBackend(Backend):
         split = onnx_node.getattr("split", None)
         num_output = len(onnx_node.outputs)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(axis, split, num_output)
 
     @classmethod
@@ -1270,7 +1271,7 @@ class SingaBackend(Backend):
             np.int32).tolist() if len(inputs) >= 2 else None
         onnx_node.consumed_inputs.extend(onnx_node.inputs[1:])
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(starts, ends, axes, steps)
 
     @classmethod
@@ -1288,7 +1289,7 @@ class SingaBackend(Backend):
         """
         axes = onnx_node.getattr("axes")
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(axes)
 
     @classmethod
@@ -1306,7 +1307,7 @@ class SingaBackend(Backend):
         """
         data_format = onnx_node.getattr("data_format", 'channels_first')
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(data_format)
 
     @classmethod
@@ -1324,7 +1325,7 @@ class SingaBackend(Backend):
         """
         alpha = onnx_node.getattr("alpha", 0.01)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(alpha)
 
     @classmethod
@@ -1343,7 +1344,7 @@ class SingaBackend(Backend):
         axes = onnx_node.getattr("axes", None)
         keepdims = onnx_node.getattr("keepdims", 1)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(axes, keepdims)
 
     @classmethod
@@ -1361,7 +1362,7 @@ class SingaBackend(Backend):
         """
         ratio = onnx_node.getattr("ratio", 0)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(ratio)
 
     @classmethod
@@ -1381,7 +1382,7 @@ class SingaBackend(Backend):
         if isinstance(value, onnx.TensorProto):
             value = numpy_helper.to_array(value)[0].item()
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(value)
 
     @classmethod
@@ -1400,7 +1401,7 @@ class SingaBackend(Backend):
         shape = inputs[0].shape
         perm = onnx_node.getattr("perm", list(range(len(shape) - 1, -1, -1)))
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(perm)
 
     @classmethod
@@ -1427,7 +1428,7 @@ class SingaBackend(Backend):
             max_v = None
         onnx_node.consumed_inputs.extend(onnx_node.inputs[1:])
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(min_v, max_v)
 
     @classmethod
@@ -1446,7 +1447,7 @@ class SingaBackend(Backend):
         alpha = onnx_node.getattr("alpha", 0.2)
         beta = onnx_node.getattr("beta", 0.5)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(alpha, beta)
 
     @classmethod
@@ -1464,7 +1465,7 @@ class SingaBackend(Backend):
         """
         alpha = onnx_node.getattr("alpha", 1.)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(alpha)
 
     @classmethod
@@ -1483,7 +1484,7 @@ class SingaBackend(Backend):
         alpha = onnx_node.getattr("alpha", 1.67326)
         gamma = onnx_node.getattr("gamma", 1.0507)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(alpha, gamma)
 
     @classmethod
@@ -1504,7 +1505,7 @@ class SingaBackend(Backend):
         shape = tensor.to_numpy(inputs.pop(1)).astype(np.int32).tolist()
         onnx_node.consumed_inputs.append(onnx_node.inputs[1])
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(shape)
 
     @classmethod
@@ -1564,7 +1565,7 @@ class SingaBackend(Backend):
                                            group)
 
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(handle, odd_padding)
 
     @classmethod
@@ -1612,7 +1613,7 @@ class SingaBackend(Backend):
                                               is_max)
 
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(handle, odd_padding)
 
     @classmethod
@@ -1638,7 +1639,7 @@ class SingaBackend(Backend):
         onnx_node.consumed_inputs.append(onnx_node.inputs[4])
 
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(handle, running_mean, running_var)
 
     @classmethod
@@ -1659,7 +1660,7 @@ class SingaBackend(Backend):
             factor = len(inputs[0].shape
                         ) + factor  # in order to support the negative axis
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(axis=factor)
 
     @classmethod
@@ -1680,7 +1681,7 @@ class SingaBackend(Backend):
             # in order to support the negative axis
             factor = len(inputs[0].shape) + factor
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(axis=factor)
 
     @classmethod
@@ -1702,11 +1703,8 @@ class SingaBackend(Backend):
         transA = onnx_node.getattr('transA', 0)
         transB = onnx_node.getattr('transB', 0)
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
-        return forward(alpha=alpha,
-                             beta=beta,
-                             transA=transA,
-                             transB=transB)
+                                                    opset_version)
+        return forward(alpha=alpha, beta=beta, transA=transA, transB=transB)
 
     @classmethod
     def _create_flatten(cls, onnx_node, inputs, opset_version):
@@ -1727,7 +1725,7 @@ class SingaBackend(Backend):
             factor = len(inputs[0].shape) + factor
 
         forward = cls._common_onnx_node_to_singa_op(onnx_node, inputs,
-                                                       opset_version)
+                                                    opset_version)
         return forward(axis=factor)
 
     @classmethod
@@ -1798,7 +1796,7 @@ class SingaBackend(Backend):
 
         tmp_inputs = [inputs[x] for x in onnx_node.inputs if x != ""]
         forward = cls._onnx_node_to_singa_op(onnx_node, tmp_inputs,
-                                                     opset_version)
+                                             opset_version)
         # only give the inputs it needs
         # consumed_inputs are the inputs marked as attributes
         # so we remove it here
@@ -1807,8 +1805,7 @@ class SingaBackend(Backend):
             for x in onnx_node.inputs
             if x not in onnx_node.consumed_inputs
         ]
-        return cls._run_node(onnx_node, tmp_inputs, forward,
-                             opset_version)
+        return cls._run_node(onnx_node, tmp_inputs, forward, opset_version)
 
     @classmethod
     def _run_node(cls,
@@ -1874,7 +1871,7 @@ class SingaBackend(Backend):
                 # so if the user gives values, we use these values
                 # if not, we just use the shape of input gived by onnx to init a random value
                 # HOWEVER, the random value may not be correct for some inputs, such as gather which needs indices
-                # so if have operators, the user must give inputs
+                # so if have these operators, the user must give inputs
                 x_shape = tuple(
                     dim.dim_value for dim in x.type.tensor_type.shape.dim)
                 if init_inputs is not None:
@@ -1924,8 +1921,7 @@ class SingaBackend(Backend):
                 for x in node.inputs
                 if x not in node.consumed_inputs
             ]
-            forward = cls._onnx_node_to_singa_op(
-                node, inputs, opset_version)
+            forward = cls._onnx_node_to_singa_op(node, inputs, opset_version)
             # if it is Constant, we hanlde it as a weight
             # otherwise, we run it and add its output into map for being used by later operators
             if node.op_type == 'Constant':
@@ -1982,7 +1978,7 @@ class SingaBackend(Backend):
         if opset_version is None:
             if model.ir_version >= 0x00000003:
                 raise RuntimeError(
-                    "Model with IR version >= 3 did not specify ONNX operator set version (singa requires it)"
+                    "Model with IR version >= 3 did not specify ONNX operator set version (SINGA requires it)"
                 )
             else:
                 opset_version = 1
@@ -2000,16 +1996,16 @@ class SingaRep(BackendRep):
                  singa_ops,
                  keep_initializers_as_inputs=True):
         """
+        https://github.com/onnx/onnx/blob/master/docs/ImplementingAnOnnxBackend.md
         SingaRep provides the intermediate representation of Singa,
         the user can run the forward of the singa model by run func,
         or, the user can append more layers after the singa_ops to do
         the transfer learning
         Args:
             model: a given operator
-        Args:
             weights: the tensor of weights
-        Args:
             singa_ops: the tensor of the operator
+            keep_initializers_as_inputs: whether inputs contains initializers
         """
         super(SingaRep, self).__init__()
         self.model = model
@@ -2032,9 +2028,9 @@ class SingaRep(BackendRep):
         # last_layers means we run this model until the last #N layers
         last_layers = kwargs.get('last_layers', len(self.singa_ops))
         if last_layers != len(self.singa_ops):
-            final_outputs = self.singa_ops[last_layers-1].op.outputs
+            final_outputs = self.singa_ops[last_layers - 1].op.outputs
         else:
-            final_outputs =  [outp.name for outp in graph.output]
+            final_outputs = [outp.name for outp in graph.output]
         # whether return all outputs
         all_outputs = kwargs.get('all_outputs', False)
         # get a specific op by its name
@@ -2052,7 +2048,7 @@ class SingaRep(BackendRep):
             actual_input_len = len(inputs)
         assert require_input_len == actual_input_len, "The length of graph input is different from the tensor input: %d, %d" % (
             require_input_len, actual_input_len)
-        # run the op by the order of the list(the list is Topological Sorting)
+        # run the op by the order of the topo list
         for inp in graph.input:
             if inp.name not in tmp_tensor_map:
                 tmp_tensor_map[inp.name] = inputs.pop(0)
@@ -2061,7 +2057,7 @@ class SingaRep(BackendRep):
             if len(op.consumed_inputs) != 0:
                 # because if op has consumed_inputs, it means it moved some inputs into attributes
                 # so when running, we should update these attributes
-               forward = get_op(op, [tmp_tensor_map[x] for x in op.inputs])
+                forward = get_op(op, [tmp_tensor_map[x] for x in op.inputs])
             inputs = [
                 tmp_tensor_map[x]
                 for x in op.inputs
@@ -2086,6 +2082,81 @@ class SingaRep(BackendRep):
             return ret_outputs
         else:
             return [ret_outputs[outp] for outp in final_outputs]
+
+
+class BaseModel(module.Module):
+
+    def __init__(self, sg_ir, loss, optimizer):
+        """
+        Init a SIGNA Module
+        Args:
+            sg_ir: a SingaRep class
+        """
+        super(BaseModel, self).__init__()
+        self.optimizer = optimizer
+        self.loss = loss
+        self.g = sg_ir.model.graph
+        self.tm = sg_ir.tensor_map
+        self.oq = sg_ir.singa_ops
+        self.input_shape = self.g.input[0].type.tensor_type.shape.dim
+        self.dimension = len(self.input_shape)
+
+    def forward(self, *x):
+        """
+        The forward of the SINGA model
+        Args:
+            x: a list of Tensor
+        Returns:
+            a list of Tensor
+        """
+        inputs = list(x)
+        for inp in self.g.input:
+            if inp.name not in self.tm:
+                self.tm[inp.name] = inputs.pop(0)
+
+        final_outputs = [outp.name for outp in self.g.output]
+        # run the op by the order of the topo list
+        for _, op, forward in self.oq:
+            inputs = [
+                self.tm[x] for x in op.inputs if x not in op.consumed_inputs
+            ]
+            outputs = _run_node(op, inputs, forward)
+            for key, val in outputs.items():
+                self.tm[key] = val
+        return [self.tm[outp] for outp in final_outputs]
+
+    def loss(self, out, ty):
+        return self.loss(out, ty)
+
+    def optim(self, loss, dist_option, spars):
+        if dist_option == 'fp32':
+            self.optimizer.backward_and_update(loss)
+        elif dist_option == 'fp16':
+            self.optimizer.backward_and_update_half(loss)
+        elif dist_option == 'partialUpdate':
+            self.optimizer.backward_and_partial_update(loss)
+        elif dist_option == 'sparseTopK':
+            self.optimizer.backward_and_sparse_update(loss,
+                                                      topK=True,
+                                                      spars=spars)
+        elif dist_option == 'sparseThreshold':
+            self.optimizer.backward_and_sparse_update(loss,
+                                                      topK=False,
+                                                      spars=spars)
+
+
+def create_model(sg_ir, loss, optimizer):
+    """
+    Init a SIGNA Module
+    Args:
+        sg_ir: a SingaRep class
+        loss: loss function
+        optim: optimization
+    Returns:
+        a Module object
+    """
+    model = BaseModel(sg_ir, loss, optimizer)
+    return model
 
 
 run_node = SingaBackend.run_node


### PR DESCRIPTION
This PR adds a class to create a [class](https://github.com/apache/singa/pull/684/files#diff-4839d7350844248bf25a18751ed06062R2087-R2161) inheriting from the autograd.module class, and now the ONNX model can be trained as SINGA model.

![image](https://user-images.githubusercontent.com/14108933/79952938-bc34b180-84ad-11ea-93ba-973cfbbb9cde.png)

However, this PR supports most ONNX models except BERT, since BERT uses lots of operators which don't have a gradient, may need to discuss it further.

TO-DO List:
- ~~add base class supports module.~~
- add training examples for:
    * ~~MobileNet~~
    * ResNet-18, 34, 50, 101, 152, v1 for pre-activation, v2 for post-activation
    * SqueezeNet
    * VGG-16, 19
    * AlexNet
    * GoogleNet
    * RCNN_ILSVRC13
    * DenseNet
    * Inception_V1
    * Inception_V2
    * ShuffleNet_V1
    * ShuffleNet_V2
    * ZFNet-512


