### PR TITLE
fix bugs of recycling

### DIFF
--- a/examples/rnn/train.py
+++ b/examples/rnn/train.py
@@ -197,7 +197,7 @@ def train(data,
     cuda = device.create_cuda_gpu()
     model = CharRNN(data.vocab_size, hidden_size)
     model.on_device(cuda)
-    model.graph(True, True)
+    model.graph(True, False)
 
     inputs, labels = None, None
 

--- a/include/singa/core/scheduler.h
+++ b/include/singa/core/scheduler.h
@@ -101,16 +101,16 @@ class BlkInfo {
         blk_(blk),
         type_(type),
         graph_ref_(0),
-        write_node_(nullptr),
-        last_node_(nullptr) {}
+        write_edge_(nullptr) {}
 
   // getters of BlkInfo
   int id() const { return id_; }
   Block *block() const { return blk_; }
   BlockType type() const { return type_; }
   int graph_ref() const { return graph_ref_; }
-  Node *write_node() const { return write_node_; }
-  Node *last_node() const { return last_node_; }
+  Edge *write_edge() const { return write_edge_; }
+  const NodeVec &used_nodes() const { return used_nodes_; }
+  Node *used_node(const size_t idx) const;
 
  private:
   friend Graph;
@@ -119,8 +119,8 @@ class BlkInfo {
   Block *blk_;
   BlockType type_;
   int graph_ref_;
-  Node *write_node_;  // last node that writes the block
-  Node *last_node_;   // last node that uses the block
+  Edge *write_edge_;    // the edge of last node that writes data into blk
+  NodeVec used_nodes_;  // the nodes that use this block(in order of execution)
 };
 
 class Graph {
@@ -167,6 +167,8 @@ class Graph {
  private:
   void Analysis();
   void FreeLoop();
+  void AnalysisNodes();
+  void AnalysisEdges();
   void AddSyncOp(function<void(Context *)> &&op);
 
   // static void CUDART_CB Callback(cudaStream_t stream, cudaError_t status,
@@ -185,6 +187,7 @@ class Graph {
 
   // Calculation graph analysis
   bool dirty_ = false;
+  bool in_serial_ = false;
   NodeVec begin_nodes_;
   std::vector<NodeVec> next_nodes_;
   std::vector<BlockVec> free_blocks_;

--- a/include/singa/core/scheduler.h
+++ b/include/singa/core/scheduler.h
@@ -97,11 +97,7 @@ class Edge {
 class BlkInfo {
  public:
   BlkInfo(int id, Block *blk, BlockType type = BlockType::kUnknow)
-      : id_(id),
-        blk_(blk),
-        type_(type),
-        graph_ref_(0),
-        write_edge_(nullptr) {}
+      : id_(id), blk_(blk), type_(type), graph_ref_(0), write_edge_(nullptr) {}
 
   // getters of BlkInfo
   int id() const { return id_; }
@@ -165,10 +161,10 @@ class Graph {
   const BlockVec &free_blocks(const size_t idx) const;
 
  private:
-  void Analysis();
+  void Analyze();
   void FreeLoop();
-  void AnalysisNodes();
-  void AnalysisEdges();
+  void AnalyzeNodes();
+  void AnalyzeEdges();
   void AddSyncOp(function<void(Context *)> &&op);
 
   // static void CUDART_CB Callback(cudaStream_t stream, cudaError_t status,

--- a/python/singa/module.py
+++ b/python/singa/module.py
@@ -48,7 +48,11 @@ class Graph(type):
                     # deconstruct Operations before running the entire graph
                     if name == 'optim':
                         for fname in self._results:
-                            self._results[fname].creator = None
+                            if isinstance(self._results[fname], list):
+                                for _matrix in self._results[fname]:
+                                    _matrix.creator = None
+                            else:
+                                self._results[fname].creator = None
                         # make sure all Operations are deallocated
                         gc.collect()
                     # add result tensor

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -251,8 +251,6 @@ void Graph::RunGraph() {
     // step 3: release some blocks' data that won't be used later
     for (auto it : free_blocks_[curIndex]) {
       it->free_data();
-      if (blocks_[it]->id_ == 1907) {
-      }
     }
 
     /*

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -104,6 +104,7 @@ void Graph::Reset() {
 void Graph::Debug() {
   if (dirty_) Analysis();
 
+  int w = 0;
   size_t max_in_num = 0, max_out_num = 0, max_next_num = 0, max_free_num = 0;
   for (auto &it : nodes_) {
     max_in_num = std::max(max_in_num, it->in_edges_.size());
@@ -118,11 +119,13 @@ void Graph::Debug() {
     max_free_num = std::max(max_free_num, it.size());
   }
 
-  int w = 2;
+  for (int i = std::max(nodes_.size(), blocks_.size()); i > 0; i /= 10, ++w)
+    ;
+
   std::stringstream ss;
   ss << "begin nodes:[";
   for (size_t i = 0; i < begin_nodes_.size(); ++i) {
-    ss << begin_nodes_[i]->id_;
+    ss << begin_nodes_[i]->id_ << " ";
   }
   ss << "]" << std::endl;
 
@@ -169,11 +172,13 @@ void Graph::Debug() {
     ss << "]" << std::endl;
   }
 
+  size_t max_used_num = 0;
   std::vector<BlkInfo *> blkInfos;
   blkInfos.resize(blocks_.size());
 
   for (auto it : blocks_) {
     blkInfos[it.second->id_] = it.second;
+    max_used_num = std::max(max_used_num, it.second->used_nodes_.size());
   }
 
   for (auto it : blkInfos) {
@@ -198,21 +203,27 @@ void Graph::Debug() {
         break;
     }
     int id = -1;
-    if (blkInfo->write_node_) {
-      id = blkInfo->write_node_->id_;
+    if (blkInfo->write_edge_) {
+      id = blkInfo->write_edge_->src_node_->id_;
     }
-    ss << " write_node[" << std::setw(w) << id << "]";
-    id = -1;
-    if (blkInfo->last_node_) {
-      id = blkInfo->last_node_->id_;
+    ss << " write_node[" << std::setw(w) << id;
+
+    ss << "] used_nodes[";
+    size = blkInfo->used_nodes_.size();
+    for (size_t i = 0; i < max_used_num; ++i) {
+      if (i < size)
+        ss << std::setw(w) << blkInfo->used_nodes_[i]->id_ << " ";
+      else
+        ss << std::setw(w + 1) << " ";
     }
-    ss << " last_node[" << std::setw(w) << id << "]" << std::endl;
+    ss << "]" << std::endl;
   }
 
   printf("%s", ss.str().c_str());
 }
 
 void Graph::RunGraph() {
+  in_serial_ = false;
   if (dirty_) Analysis();
 
   SafeQueue<Node *> node_queue;
@@ -235,6 +246,8 @@ void Graph::RunGraph() {
     // step 3: release some blocks' data that won't be used later
     for (auto it : free_blocks_[curIndex]) {
       it->free_data();
+      if (blocks_[it]->id_ == 1907) {
+      }
     }
 
     /*
@@ -253,6 +266,7 @@ void Graph::RunGraph() {
 }
 
 void Graph::RunInSerial() {
+  in_serial_ = true;
   if (dirty_) Analysis();
 
   for (size_t i = 0; i < nodes_.size(); ++i) {
@@ -279,6 +293,8 @@ void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,
                          const BlockVec &write_blocks) {
   dirty_ = true;
 
+  // if the size of both read_blocks and write_blocks is zero,
+  // this operation is used for synchronization
   if (read_blocks.size() == 0 && write_blocks.size() == 0) {
     AddSyncOp(std::move(op));
     return;
@@ -290,12 +306,11 @@ void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,
   // create edges for read_blocks
   for (size_t i = 0; i < read_blocks.size(); ++i) {
     Block *blk = read_blocks[i];
-    Edge *edge = nullptr;
+    Node *src_node = nullptr;
     BlkInfo *blkInfo = nullptr;
 
     auto it = blocks_.find(blk);
     if (it == blocks_.end()) {
-      edge = new Edge(edges_.size(), blk, nullptr, node);
       blkInfo = new BlkInfo(blocks_.size(), blk, BlockType::kInput);
       blocks_[blk] = blkInfo;
     } else {
@@ -304,15 +319,25 @@ void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,
         blkInfo->type_ = BlockType::kInter;
       }
 
-      Node *write_node = blkInfo->write_node_;
-      edge = new Edge(edges_.size(), blk, write_node, node);
-      if (write_node) {
-        write_node->AddOutEdge(edge);
+      Edge *write_edge = blkInfo->write_edge_;
+      if (write_edge) {
+        if (!write_edge->dst_node_) {
+          // change the dst node of the write_edge
+          write_edge->dst_node_ = node;
+          node->AddInEdge(write_edge);
+          blkInfo->graph_ref_ += 1;
+          continue;
+        } else {
+          src_node = write_edge->src_node_;
+        }
       }
     }
 
+    Edge *edge = new Edge(edges_.size(), blk, src_node, node);
     blkInfo->graph_ref_ += 1;
-    blkInfo->last_node_ = node;
+    if (src_node) {
+      src_node->AddOutEdge(edge);
+    }
 
     node->AddInEdge(edge);
     edges_.push_back(edge);
@@ -334,9 +359,12 @@ void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,
       }
     }
 
+    Edge *edge = new Edge(edges_.size(), blk, node, nullptr);
+    blkInfo->write_edge_ = edge;
     blkInfo->graph_ref_ += 1;
-    blkInfo->write_node_ = node;
-    blkInfo->last_node_ = node;
+
+    node->AddOutEdge(edge);
+    edges_.push_back(edge);
   }
 
   // for sync op
@@ -349,66 +377,87 @@ void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,
 void Graph::Analysis() {
   begin_nodes_.clear();
   next_nodes_.resize(nodes_.size());
+  free_blocks_.clear();
   free_blocks_.resize(nodes_.size());
 
-  // init node ref
-  std::vector<int> node_ref_;
-  node_ref_.resize(nodes_.size());
-  for (size_t i = 0; i < nodes_.size(); ++i) {
-    node_ref_[i] = nodes_[i]->in_edges_.size();
+  for (auto &it : blocks_) {
+    it.second->used_nodes_.clear();
   }
 
-  // find all input edges and decrease ref count of nodes
-  for (size_t i = 0; i < edges_.size(); ++i) {
-    Node *src_node = edges_[i]->src_node_;
-    if (!src_node) {
-      Node *node = edges_[i]->dst_node_;
-      int nodeId = node->id_;
-      node_ref_[nodeId] -= 1;
+  AnalysisNodes();
+
+  AnalysisEdges();
+
+  dirty_ = false;
+
+  // Debug();
+}
+
+void Graph::AnalysisNodes() {
+  if (in_serial_) {
+    begin_nodes_.push_back(nodes_[0]);
+
+    for (size_t i = 0; i < nodes_.size() - 1; ++i) {
+      Node *curNode  = nodes_[i];
+
+      next_nodes_[i].push_back(nodes_[i + 1]);
+
+      std::unordered_set<Block *> blks;
+      for (size_t j = 0; j < curNode->in_edges_.size(); ++j) {
+        blks.insert(curNode->in_edges_[j]->blk_);
+      }
+      for (size_t j = 0; j < curNode->out_edges_.size(); ++j) {
+        blks.insert(curNode->out_edges_[j]->blk_);
+      }
+
+      for (auto &it : blks) {
+        blocks_[it]->used_nodes_.push_back(curNode);
+      }
     }
-  }
-
-  // activate nodes
-  SafeQueue<Node *> node_queue;
-  for (size_t i = 0; i < node_ref_.size(); ++i) {
-    if (node_ref_[i] == 0) {
-      begin_nodes_.push_back(nodes_[i]);
-      node_queue.Push(nodes_[i]);
+  } else {
+    // init node ref
+    std::vector<int> node_ref_;
+    node_ref_.resize(nodes_.size());
+    for (size_t i = 0; i < nodes_.size(); ++i) {
+      node_ref_[i] = nodes_[i]->in_edges_.size();
     }
-  }
 
-  // run graph
-  while (node_queue.Size()) {
-    // step 1: pop the first element, get the node corresponding to the index
-    Node *curNode = nullptr;
-    node_queue.Pop(curNode);
-    int curIndex = curNode->id_;
-
-    // step 2: release some blocks' data that won't be used later
-    free_blocks_[curIndex].clear();
-    for (size_t i = 0; i < curNode->in_edges_.size(); ++i) {
-      Edge *edge = curNode->in_edges_[i];
-      Block *blk = edge->blk_;
-      BlkInfo *blkInfo = blocks_[blk];
-      // if curnode is the last node accessing the block
-      if (blkInfo->last_node_ == curNode) {
-        BlockType type = blkInfo->type_;
-        // if the block belongs to a inter tensor
-        // and isn't refered on the Python Side
-        if ((type == BlockType::kInter || type == BlockType::kEnd) &&
-            blkInfo->graph_ref_ >= blk->ref_count()) {
-          free_blocks_[curIndex].push_back(blk);
-        }
+    // find all input edges and decrease ref count of nodes
+    for (size_t i = 0; i < edges_.size(); ++i) {
+      Node *src_node = edges_[i]->src_node_;
+      if (!src_node) {
+        Node *node = edges_[i]->dst_node_;
+        int nodeId = node->id_;
+        node_ref_[nodeId] -= 1;
       }
     }
 
-    // step 3: decrease ref count of nodes and activate nodes
-    next_nodes_[curIndex].clear();
-    for (size_t i = 0; i < curNode->out_edges_.size(); ++i) {
-      Edge *edge = curNode->out_edges_[i];
-      Node *nextNode = edge->dst_node_;
+    // activate nodes
+    SafeQueue<Node *> node_queue;
+    for (size_t i = 0; i < node_ref_.size(); ++i) {
+      if (node_ref_[i] == 0) {
+        begin_nodes_.push_back(nodes_[i]);
+        node_queue.Push(nodes_[i]);
+      }
+    }
 
-      if (nextNode) {
+    // run graph
+    while (node_queue.Size()) {
+      // step 1: pop the first element, get the node corresponding to the index
+      Node *curNode = nullptr;
+      node_queue.Pop(curNode);
+      int curIndex = curNode->id_;
+
+      // step 2: decrease ref count of nodes and activate nodes
+      next_nodes_[curIndex].clear();
+      for (size_t i = 0; i < curNode->out_edges_.size(); ++i) {
+        Edge *edge = curNode->out_edges_[i];
+        Node *nextNode = edge->dst_node_;
+
+        if (!nextNode) {
+          continue;
+        }
+
         int nodeId = nextNode->id_;
         node_ref_[nodeId] -= 1;
         if (node_ref_[nodeId] <= 0) {
@@ -416,12 +465,40 @@ void Graph::Analysis() {
           next_nodes_[curIndex].push_back(nextNode);
         }
       }
+
+      // step 3: push_back curNode to the used_nodes_ of relevant blocks
+      std::unordered_set<Block *> blks;
+      for (size_t j = 0; j < curNode->in_edges_.size(); ++j) {
+        blks.insert(curNode->in_edges_[j]->blk_);
+      }
+      for (size_t j = 0; j < curNode->out_edges_.size(); ++j) {
+        blks.insert(curNode->out_edges_[j]->blk_);
+      }
+
+      for (auto &it : blks) {
+        blocks_[it]->used_nodes_.push_back(curNode);
+      }
     }
   }
+}
 
-  dirty_ = false;
+void Graph::AnalysisEdges() {
+  for (auto &it : blocks_) {
+    Block *blk = it.first;
+    BlkInfo *blkInfo = it.second;
 
-  // Debug();
+    if (blkInfo->used_nodes_.size()) {
+      int node_id = blkInfo->used_nodes_.back()->id_;
+      BlockType type = blkInfo->type_;
+
+      // if the block belongs to a inter tensor
+      // and isn't refered on the Python Side
+      if ((type == BlockType::kInter || type == BlockType::kEnd) &&
+          blkInfo->graph_ref_ >= blk->ref_count()) {
+        free_blocks_[node_id].push_back(blk);
+      }
+    }
+  }
 }
 
 void Graph::FreeLoop() {
@@ -445,22 +522,31 @@ void Graph::AddSyncOp(function<void(Context *)> &&op) {
   for (size_t i = 0; i < write_blocks_.size(); ++i) {
     Block *blk = write_blocks_[i];
     BlkInfo *blkInfo = blocks_[blk];
+    Edge *edge = nullptr;
 
     if (blkInfo->type_ == BlockType::kEnd) {
       blkInfo->type_ = BlockType::kInter;
     }
 
-    Node *write_node = blkInfo->write_node_;
-    Edge *edge = new Edge(edges_.size(), blk, write_node, node);
-    if (write_node) {
-      write_node->AddOutEdge(edge);
+    Edge *write_edge = blkInfo->write_edge_;
+    if (!write_edge->dst_node_) {
+      // change the dst node of the write_edge
+      write_edge->dst_node_ = node;
+      edge = write_edge;
+    } else {
+      Node *src_node = write_edge->src_node_;
+      edge = new Edge(edges_.size(), blk, src_node, node);
+      src_node->AddOutEdge(edge);
+      edges_.push_back(edge);
     }
 
-    // fake edges, no need to add the graph ref
-    blkInfo->last_node_ = node;
-    blkInfo->write_node_ = node;
-
     node->AddInEdge(edge);
+
+    // fake edges, no need to add the graph ref
+    edge = new Edge(edges_.size(), blk, node, nullptr);
+    blkInfo->write_edge_ = edge;
+
+    node->AddOutEdge(edge);
     edges_.push_back(edge);
   }
 

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -124,8 +124,8 @@ void Graph::Debug() {
     max_free_num = std::max(max_free_num, it.size());
   }
 
-  for (int i = std::max(nodes_.size(), blocks_.size()); i > 0; i /= 10, ++w)
-    ;
+  for (int i = std::max(nodes_.size(), blocks_.size()); i > 0; i /= 10, ++w) {
+  }
 
   std::stringstream ss;
   ss << "begin nodes:[";

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -102,7 +102,7 @@ void Graph::Reset() {
 }
 
 void Graph::Debug() {
-  if (dirty_) Analysis();
+  if (dirty_) Analyze();
 
   int w = 0;
   size_t max_in_num = 0, max_out_num = 0, max_next_num = 0, max_free_num = 0;
@@ -224,7 +224,7 @@ void Graph::Debug() {
 
 void Graph::RunGraph() {
   in_serial_ = false;
-  if (dirty_) Analysis();
+  if (dirty_) Analyze();
 
   SafeQueue<Node *> node_queue;
 
@@ -267,7 +267,7 @@ void Graph::RunGraph() {
 
 void Graph::RunInSerial() {
   in_serial_ = true;
-  if (dirty_) Analysis();
+  if (dirty_) Analyze();
 
   for (size_t i = 0; i < nodes_.size(); ++i) {
     Node *curNode = nodes_[i];
@@ -374,7 +374,7 @@ void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,
   nodes_.push_back(node);
 }
 
-void Graph::Analysis() {
+void Graph::Analyze() {
   begin_nodes_.clear();
   next_nodes_.resize(nodes_.size());
   free_blocks_.clear();
@@ -384,21 +384,21 @@ void Graph::Analysis() {
     it.second->used_nodes_.clear();
   }
 
-  AnalysisNodes();
+  AnalyzeNodes();
 
-  AnalysisEdges();
+  AnalyzeEdges();
 
   dirty_ = false;
 
   // Debug();
 }
 
-void Graph::AnalysisNodes() {
+void Graph::AnalyzeNodes() {
   if (in_serial_) {
     begin_nodes_.push_back(nodes_[0]);
 
     for (size_t i = 0; i < nodes_.size() - 1; ++i) {
-      Node *curNode  = nodes_[i];
+      Node *curNode = nodes_[i];
 
       next_nodes_[i].push_back(nodes_[i + 1]);
 
@@ -482,7 +482,7 @@ void Graph::AnalysisNodes() {
   }
 }
 
-void Graph::AnalysisEdges() {
+void Graph::AnalyzeEdges() {
   for (auto &it : blocks_) {
     Block *blk = it.first;
     BlkInfo *blkInfo = it.second;

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -44,6 +44,11 @@ Graph::Graph(Device *device) : device_(device) {}
 
 Graph::~Graph() { Reset(); }
 
+Node *BlkInfo::used_node(const size_t idx) const {
+  CHECK_LT(idx, used_nodes_.size());
+  return used_nodes_[idx];
+}
+
 Node *Graph::node(const size_t idx) const {
   CHECK_LT(idx, nodes_.size());
   return nodes_[idx];

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -189,7 +189,8 @@ void Graph::Debug() {
   for (auto it : blkInfos) {
     auto blkInfo = it;
     ss << "Block[" << std::setw(w) << blkInfo->id_ << "] addr[" << std::setw(w)
-       << blkInfo->blk_ << "] graph_ref[" << std::setw(w) << blkInfo->graph_ref_
+       << blkInfo->blk_ << "] size[" << std::setw(10) << blkInfo->blk_->size()
+       << "] graph_ref[" << std::setw(w) << blkInfo->graph_ref_
        << "] ref_count[" << std::setw(w) << blkInfo->blk_->ref_count() << "] ";
     switch (blkInfo->type_) {
       case BlockType::kInput:


### PR DESCRIPTION
In this pr, I have fixed some bugs for automatic recycling. This is due to incorrect dependency analysis when using the same tensor for multiple operations when executing programs in the order of DFS. Now, the RNN model in the examples dir can be trained in graph mode.
Besides, I also optimized the Analysis function, Debug function, and the structure of the graph.