### PR TITLE
SINGA-510 Add Time Profiling for Single GPU

### DIFF
--- a/examples/cnn/train.py
+++ b/examples/cnn/train.py
@@ -188,7 +188,6 @@ def run(global_rank,
     model.graph(graph, sequential)
     
     dev.SetVerbosity(verbosity)
-    # dev.SetProfilingMode(singa.useEvent)
 
     # Training and Evaluation Loop
     for epoch in range(max_epoch):

--- a/examples/cnn/train.py
+++ b/examples/cnn/train.py
@@ -188,7 +188,7 @@ def run(global_rank,
     model.graph(graph, sequential)
     
     dev.SetVerbosity(verbosity)
-    # dev.SetProfilingMode('CHRONO')
+    # dev.SetProfilingMode(singa.useEvent)
 
     # Training and Evaluation Loop
     for epoch in range(max_epoch):

--- a/examples/cnn/train_mpi.py
+++ b/examples/cnn/train_mpi.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
                         default='fp32',
                         choices=['fp32','fp16','partialUpdate','sparseTopK','sparseThreshold'],
                         help='distibuted training options',
-                        dest='dist_option')  # currently partialUpdate support graph=False only 
+                        dest='dist_option')  # currently partialUpdate support graph=False only
     parser.add_argument('--spars',
                         '--sparsification',
                         default='0.05',
@@ -67,6 +67,12 @@ if __name__ == '__main__':
                         action='store_false',
                         help='disable graph',
                         dest='graph')
+    parser.add_argument('--verbosity',
+                        '--log-verbosity',
+                        default=0,
+                        type=int,
+                        help='logging verbosity',
+                        dest='verbosity')
 
     args = parser.parse_args()
 
@@ -74,4 +80,5 @@ if __name__ == '__main__':
     sgd = opt.DistOpt(sgd)
 
     train.run(sgd.global_rank, sgd.world_size, sgd.local_rank, args.max_epoch,
-              args.batch_size, args.model, args.data, sgd, args.graph, args.dist_option, args.spars)
+              args.batch_size, args.model, args.data, sgd, args.graph,
+              args.verbosity, args.dist_option, args.spars)

--- a/examples/cnn/train_multiprocess.py
+++ b/examples/cnn/train_multiprocess.py
@@ -27,8 +27,9 @@ import multiprocessing
 def run(args, local_rank, world_size, nccl_id):
     sgd = opt.SGD(lr=args.lr, momentum=0.9, weight_decay=1e-5)
     sgd = opt.DistOpt(sgd, nccl_id=nccl_id, local_rank=local_rank, world_size=world_size)
-    train.run(sgd.global_rank, sgd.world_size, sgd.local_rank,
-              args.max_epoch, args.batch_size, args.model, args.data, sgd, args.graph, args.dist_option, args.spars)
+    train.run(sgd.global_rank, sgd.world_size, sgd.local_rank, args.max_epoch,
+              args.batch_size, args.model, args.data, sgd, args.graph,
+              args.verbosity, args.dist_option, args.spars)
 
 
 if __name__ == '__main__':
@@ -68,7 +69,7 @@ if __name__ == '__main__':
                         default='fp32',
                         choices=['fp32','fp16','partialUpdate','sparseTopK','sparseThreshold'],
                         help='distibuted training options',
-                        dest='dist_option') # currently partialUpdate support graph=False only 
+                        dest='dist_option') # currently partialUpdate support graph=False only
     parser.add_argument('--spars',
                         '--sparsification',
                         default='0.05',
@@ -81,7 +82,12 @@ if __name__ == '__main__':
                         action='store_false',
                         help='disable graph',
                         dest='graph')
-
+    parser.add_argument('--verbosity',
+                        '--log-verbosity',
+                        default=0,
+                        type=int,
+                        help='logging verbosity',
+                        dest='verbosity')
 
     args = parser.parse_args()
 

--- a/include/singa/core/device.h
+++ b/include/singa/core/device.h
@@ -51,6 +51,17 @@ using std::vector;
 
 namespace singa {
 
+/// Method used by time profiling
+/// ProfilingMode == 0 (default) -> Chrono
+/// ProfilingMode == 1 -> Event (e.g. cudaEvent)
+enum ProfilingMode { useChrono, useEvent };
+
+/// Verbosity of the time profiling function:
+/// Verbosity == 0 (default) -> no logging
+/// Verbosity == 1 -> display forward and backward propagation time
+/// Verbosity == 2 -> display each operation time (OP_ID, op name, time)
+enum Verbosity { disableLog, forwardBackwardTime, eachOperation };
+
 /// Allocate memory and execute Tensor operations.
 /// There are three types of devices distinguished by their programming
 /// languages, namely cpp, cuda and opencl.
@@ -110,17 +121,13 @@ class Device {
 
   bool graph_enabled() const { return graph_enabled_; }
 
-  /// verbosity of the time profiling function:
-  /// verbosity == 0 (default) -> no logging
-  /// verbosity == 1 -> display forward and backward propagation time
-  /// verbosity == 2 -> display each operation time (OP_ID, op name, time)
-  float verbosity() const { return verbosity_; }
+  Verbosity verbosity() const { return verbosity_; }
 
   virtual std::shared_ptr<Device> host() const { return host_; }
 
   void PrintTimeProfiling();
-  void SetVerbosity(int verbosity) { verbosity_ = verbosity; };
-  void SetProfilingMode(string profiling_mode) {
+  void SetVerbosity(Verbosity verbosity) { verbosity_ = verbosity; };
+  void SetProfilingMode(ProfilingMode profiling_mode) {
     profiling_mode_ = profiling_mode;
   };
 
@@ -150,8 +157,8 @@ class Device {
   int num_executors_ = 0;
   unsigned seed_ = 0;
   bool graph_enabled_ = false;
-  string profiling_mode_ = "CHRONO";
-  int verbosity_ = 0;
+  ProfilingMode profiling_mode_ = useChrono;
+  Verbosity verbosity_ = disableLog;
   /// The computational graph
   Graph* graph_ = nullptr;
   /// Programming language type, could be kCpp, kCuda, kOpencl

--- a/include/singa/core/device.h
+++ b/include/singa/core/device.h
@@ -19,6 +19,7 @@
 #ifndef SINGA_CORE_DEVICE_H_
 #define SINGA_CORE_DEVICE_H_
 
+#include <chrono>
 #include <functional>
 #include <map>
 #include <memory>
@@ -87,7 +88,8 @@ class Device {
   /// Submit the operation to the device, which may execute it right now or
   /// delay it depending on the scheduler.
   void Exec(function<void(Context*)>&& fn, const vector<Block*> read_blocks,
-            const vector<Block*> write_blocks, bool use_rand_generator = false);
+            const vector<Block*> write_blocks, string op_name = "no_name",
+            bool use_rand_generator = false);
 
   void RunGraph(bool serial = false);
 
@@ -108,11 +110,25 @@ class Device {
 
   bool graph_enabled() const { return graph_enabled_; }
 
+  /// verbosity of the time profiling function:
+  /// verbosity == 0 (default) -> no logging
+  /// verbosity == 1 -> display forward and backward propagation time
+  /// verbosity == 2 -> display each operation time (OP_ID, op name, time)
+  float verbosity() const { return verbosity_; }
+
   virtual std::shared_ptr<Device> host() const { return host_; }
+
+  void PrintTimeProfiling();
+  void SetVerbosity(int verbosity) { verbosity_ = verbosity; };
+  void SetProfilingMode(string profiling_mode) {
+    profiling_mode_ = profiling_mode;
+  };
 
  protected:
   /// Execute one operation on one executor.
   virtual void DoExec(function<void(Context*)>&& fn, int executor) = 0;
+  virtual float TimeProfilingDoExec(function<void(Context*)>&& fn,
+                                    int executor) = 0;
 
   virtual void CopyToFrom(void* dst, const void* src, size_t nBytes,
                           CopyDirection direction, Context* ctx) = 0;
@@ -134,6 +150,8 @@ class Device {
   int num_executors_ = 0;
   unsigned seed_ = 0;
   bool graph_enabled_ = false;
+  string profiling_mode_ = "CHRONO";
+  int verbosity_ = 0;
   /// The computational graph
   Graph* graph_ = nullptr;
   /// Programming language type, could be kCpp, kCuda, kOpencl
@@ -165,6 +183,8 @@ class CppCPU : public Device {
 
  protected:
   void DoExec(function<void(Context*)>&& fn, int executor) override;
+  float TimeProfilingDoExec(function<void(Context*)>&& fn,
+                            int executor) override;
 
   void CopyToFrom(void* dst, const void* src, size_t nBytes,
                   CopyDirection direction, Context* ctx) override;
@@ -195,6 +215,9 @@ class CudaGPU : public Device {
 
  protected:
   void DoExec(function<void(Context*)>&& fn, int executor) override;
+  float TimeProfilingDoExec(function<void(Context*)>&& fn,
+                            int executor) override;
+  void SyncBeforeCountingTime();
 
   void CopyToFrom(void* dst, const void* src, size_t nBytes,
                   CopyDirection direction, Context* ctx) override;

--- a/include/singa/core/device.h
+++ b/include/singa/core/device.h
@@ -51,17 +51,6 @@ using std::vector;
 
 namespace singa {
 
-/// Method used by time profiling
-/// ProfilingMode == 0 (default) -> Chrono
-/// ProfilingMode == 1 -> Event (e.g. cudaEvent)
-enum ProfilingMode { useChrono, useEvent };
-
-/// Verbosity of the time profiling function:
-/// Verbosity == 0 (default) -> no logging
-/// Verbosity == 1 -> display forward and backward propagation time
-/// Verbosity == 2 -> display each operation time (OP_ID, op name, time)
-enum Verbosity { disableLog, forwardBackwardTime, eachOperation };
-
 /// Allocate memory and execute Tensor operations.
 /// There are three types of devices distinguished by their programming
 /// languages, namely cpp, cuda and opencl.
@@ -121,15 +110,16 @@ class Device {
 
   bool graph_enabled() const { return graph_enabled_; }
 
-  Verbosity verbosity() const { return verbosity_; }
+  /// Verbosity of the time profiling function:
+  /// verbosity == 0 (default) -> no logging
+  /// verbosity == 1 -> display forward and backward propagation time
+  /// verbosity == 2 -> display each operation time (OP_ID, op name, time)
+  int verbosity() const { return verbosity_; }
 
   virtual std::shared_ptr<Device> host() const { return host_; }
 
   void PrintTimeProfiling();
-  void SetVerbosity(Verbosity verbosity) { verbosity_ = verbosity; };
-  void SetProfilingMode(ProfilingMode profiling_mode) {
-    profiling_mode_ = profiling_mode;
-  };
+  void SetVerbosity(int verbosity) { verbosity_ = verbosity; };
 
  protected:
   /// Execute one operation on one executor.
@@ -157,8 +147,7 @@ class Device {
   int num_executors_ = 0;
   unsigned seed_ = 0;
   bool graph_enabled_ = false;
-  ProfilingMode profiling_mode_ = useChrono;
-  Verbosity verbosity_ = disableLog;
+  int verbosity_ = 0;
   /// The computational graph
   Graph* graph_ = nullptr;
   /// Programming language type, could be kCpp, kCuda, kOpencl

--- a/include/singa/core/scheduler.h
+++ b/include/singa/core/scheduler.h
@@ -25,6 +25,7 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
+#include <string>
 
 #include "singa/core/common.h"
 #include "singa/utils/safe_queue.h"
@@ -32,6 +33,7 @@
 using std::function;
 using std::unordered_map;
 using std::vector;
+using std::string;
 
 namespace singa {
 
@@ -51,15 +53,21 @@ enum BlockType { kUnknow, kInput, kParam, kInter, kEnd };
 
 class Node {
  public:
-  Node(int id, OpFunc &&op) : id_(id), op_(std::move(op)) {}
+  Node(int id, OpFunc &&op, string op_name) : id_(id), op_(std::move(op)), op_name_(op_name) {}
 
   void AddInEdge(Edge *in_edge);
   void AddOutEdge(Edge *out_edge);
 
   // getters of Node
   int id() const { return id_; }
+  string op_name() const { return op_name_; }
   const EdgeVec &in_edges() const { return in_edges_; }
   const EdgeVec &out_edges() const { return out_edges_; }
+  float time_elapsed() const { return time_elapsed_; }
+  float iteration() const { return iteration_; }
+  
+  // time profiling
+  void time_elapsed_inc(float time) { time_elapsed_ += time; iteration_ ++; }
 
  private:
   friend Graph;
@@ -68,6 +76,11 @@ class Node {
   OpFunc op_;
   EdgeVec in_edges_;
   EdgeVec out_edges_;
+
+  string op_name_;
+  float time_elapsed_ = 0;
+  int iteration_ = 0;
+ 
 };
 
 class Edge {
@@ -136,7 +149,7 @@ class Graph {
   void RunGraph();
   void RunInSerial();
   void AddOperation(OpFunc &&op, const BlockVec &read_blocks,
-                    const BlockVec &write_blocks);
+                    const BlockVec &write_blocks, string op_name = "no_name");
 
   // getters of Graph
   const NodeVec &nodes() const { return nodes_; }
@@ -160,12 +173,15 @@ class Graph {
   const NodeVec &next_nodes(const size_t idx) const;
   const BlockVec &free_blocks(const size_t idx) const;
 
+  void PrintTimeProfiling();
+
  private:
   void Analyze();
   void FreeLoop();
   void AnalyzeNodes();
   void AnalyzeEdges();
-  void AddSyncOp(function<void(Context *)> &&op);
+  void AddSyncOp(function<void(Context *)> &&op, string op_name = "no_name");
+  void TimeProfilingDoExec(Node *curNode);
 
   // static void CUDART_CB Callback(cudaStream_t stream, cudaError_t status,
   //                                void *data);

--- a/include/singa/core/scheduler.h
+++ b/include/singa/core/scheduler.h
@@ -64,10 +64,9 @@ class Node {
   const EdgeVec &in_edges() const { return in_edges_; }
   const EdgeVec &out_edges() const { return out_edges_; }
   float time_elapsed() const { return time_elapsed_; }
-  float iteration() const { return iteration_; }
   
   // time profiling
-  void time_elapsed_inc(float time) { time_elapsed_ += time; iteration_ ++; }
+  void time_elapsed_inc(float time) { time_elapsed_ += time; }
 
  private:
   friend Graph;
@@ -79,7 +78,6 @@ class Node {
 
   string op_name_;
   float time_elapsed_ = 0;
-  int iteration_ = 0;
  
 };
 
@@ -162,6 +160,7 @@ class Graph {
   const NodeVec &begin_nodes() const { return begin_nodes_; }
   const std::vector<NodeVec> &next_nodes() const { return next_nodes_; }
   const std::vector<BlockVec> &free_blocks() const { return free_blocks_; }
+  float iteration() const { return iteration_; }
 
   Node *node(const size_t idx) const;
   Edge *edge(const size_t idx) const;
@@ -182,6 +181,7 @@ class Graph {
   void AnalyzeEdges();
   void AddSyncOp(function<void(Context *)> &&op, string op_name = "no_name");
   void TimeProfilingDoExec(Node *curNode);
+  void step() { iteration_++; }
 
   // static void CUDART_CB Callback(cudaStream_t stream, cudaError_t status,
   //                                void *data);
@@ -203,6 +203,7 @@ class Graph {
   NodeVec begin_nodes_;
   std::vector<NodeVec> next_nodes_;
   std::vector<BlockVec> free_blocks_;
+  int iteration_ = 0;
 
   SafeQueue<int> free_queue_;
 };

--- a/src/api/core_device.i
+++ b/src/api/core_device.i
@@ -43,6 +43,9 @@ namespace std{
 
 namespace singa{
 
+enum ProfilingMode { useChrono, useEvent };
+enum Verbosity { disableLog, forwardBackwardTime, eachOperation };
+
 class Device {
  public:
   virtual void SetRandSeed(unsigned seed) = 0;
@@ -54,8 +57,8 @@ class Device {
   bool graph_enabled() const;
   void EnableGraph(bool enable);
   void PrintTimeProfiling();
-  void SetVerbosity(int verbosity);
-  void SetProfilingMode(std::string profiling_mode);
+  void SetVerbosity(Verbosity verbosity);
+  void SetProfilingMode(ProfilingMode profiling_mode);
   static void EnableLazyAlloc(bool enbale);
 };
 

--- a/src/api/core_device.i
+++ b/src/api/core_device.i
@@ -53,6 +53,9 @@ class Device {
   void RunGraph(bool serial = false);
   bool graph_enabled() const;
   void EnableGraph(bool enable);
+  void PrintTimeProfiling();
+  void SetVerbosity(int verbosity);
+  void SetProfilingMode(std::string profiling_mode);
   static void EnableLazyAlloc(bool enbale);
 };
 

--- a/src/api/core_device.i
+++ b/src/api/core_device.i
@@ -43,9 +43,6 @@ namespace std{
 
 namespace singa{
 
-enum ProfilingMode { useChrono, useEvent };
-enum Verbosity { disableLog, forwardBackwardTime, eachOperation };
-
 class Device {
  public:
   virtual void SetRandSeed(unsigned seed) = 0;
@@ -57,8 +54,7 @@ class Device {
   bool graph_enabled() const;
   void EnableGraph(bool enable);
   void PrintTimeProfiling();
-  void SetVerbosity(Verbosity verbosity);
-  void SetProfilingMode(ProfilingMode profiling_mode);
+  void SetVerbosity(int verbosity);
   static void EnableLazyAlloc(bool enbale);
 };
 

--- a/src/core/device/cpp_cpu.cc
+++ b/src/core/device/cpp_cpu.cc
@@ -40,6 +40,16 @@ void CppCPU::DoExec(function<void(Context*)>&& fn, int executor) {
   fn(&ctx_);
 }
 
+float CppCPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor) {
+  CHECK_EQ(executor, 0);
+
+  auto t_start = std::chrono::high_resolution_clock::now();
+  fn(&ctx_);
+  std::chrono::duration<float> duration =
+      std::chrono::high_resolution_clock::now() - t_start;
+  return duration.count();
+}
+
 void* CppCPU::Malloc(int size) {
   if (size > 0) {
     void* ptr = malloc(size);

--- a/src/core/device/cuda_gpu.cc
+++ b/src/core/device/cuda_gpu.cc
@@ -104,7 +104,7 @@ void CudaGPU::SyncBeforeCountingTime() {
 }
 
 float CudaGPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor) {
-  if (profiling_mode_ == "CHRONO") {
+  if (profiling_mode_ == useChrono) {
     // time profiling using chrono
     SyncBeforeCountingTime();
     auto t_start = std::chrono::high_resolution_clock::now();

--- a/src/core/device/cuda_gpu.cc
+++ b/src/core/device/cuda_gpu.cc
@@ -95,6 +95,46 @@ void CudaGPU::SetRandSeed(unsigned seed) {
 
 void CudaGPU::DoExec(function<void(Context*)>&& fn, int executor) { fn(&ctx_); }
 
+void CudaGPU::SyncBeforeCountingTime() {
+  // synchronization before counting time
+  bool previous_state = graph_enabled();
+  graph_enabled_ = false;
+  Sync();
+  graph_enabled_ = previous_state;
+}
+
+float CudaGPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor) {
+  if (profiling_mode_ == "CHRONO") {
+    // time profiling using chrono
+    SyncBeforeCountingTime();
+    auto t_start = std::chrono::high_resolution_clock::now();
+    fn(&ctx_);
+    SyncBeforeCountingTime();
+    std::chrono::duration<float> duration =
+        std::chrono::high_resolution_clock::now() - t_start;
+    return duration.count();
+  } else {
+    // time profiling using cudaEvent
+    cudaEvent_t start, end;
+    cudaEventCreate(&start);
+    cudaEventCreate(&end);
+
+    cudaEventRecord(start, ctx_.stream);
+    fn(&ctx_);
+    cudaDeviceSynchronize();
+    cudaEventRecord(end, ctx_.stream);
+
+    cudaEventSynchronize(end);
+    float totalTime;
+    cudaEventElapsedTime(&totalTime, start, end);
+
+    cudaEventDestroy(start);
+    cudaEventDestroy(end);
+
+    return totalTime * 0.001;  // convert ms to s
+  }
+}
+
 void CudaGPU::CopyToFrom(void* dst, const void* src, size_t nBytes,
                          CopyDirection direction, Context* ctx) {
   // cudaMemcpy(dst, src, nBytes, copyKind[direction]);
@@ -132,7 +172,7 @@ void CudaGPU::Free(void* ptr) {
 
 void CudaGPU::Sync() {
   Exec([this](Context* ctx) { CUDA_CHECK(cudaStreamSynchronize(ctx_.stream)); },
-       {}, {});
+       {}, {}, "Sync");
 }
 
 }  // namespace singa

--- a/src/core/device/cuda_gpu.cc
+++ b/src/core/device/cuda_gpu.cc
@@ -104,16 +104,7 @@ void CudaGPU::SyncBeforeCountingTime() {
 }
 
 float CudaGPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor) {
-  if (profiling_mode_ == useChrono) {
-    // time profiling using chrono
-    SyncBeforeCountingTime();
-    auto t_start = std::chrono::high_resolution_clock::now();
-    fn(&ctx_);
-    SyncBeforeCountingTime();
-    std::chrono::duration<float> duration =
-        std::chrono::high_resolution_clock::now() - t_start;
-    return duration.count();
-  } else {
+
     // time profiling using cudaEvent
     cudaEvent_t start, end;
     cudaEventCreate(&start);
@@ -132,7 +123,7 @@ float CudaGPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor) 
     cudaEventDestroy(end);
 
     return totalTime * 0.001;  // convert ms to s
-  }
+
 }
 
 void CudaGPU::CopyToFrom(void* dst, const void* src, size_t nBytes,

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -233,7 +233,7 @@ void Graph::PrintTimeProfiling() {
   std::stringstream ss;
 
   // verbosity level: 1 -> forward and backward propagation time
-  if (device_->verbosity() == forwardBackwardTime) {
+  if (device_->verbosity() == 1) {
     bool forward = true;
     float forward_time = 0;
     float backward_time = 0;
@@ -265,7 +265,7 @@ void Graph::PrintTimeProfiling() {
   }
 
   // verbosity level: 2 -> each operation time (OP_ID, operation name, time)
-  if (device_->verbosity() == eachOperation) {
+  if (device_->verbosity() == 2) {
     ss << std::endl << "Time Profiling:" << std::endl;
     for (size_t i = 0; i < nodes_.size(); ++i)
       if (nodes_[i]->time_elapsed() > 0)

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <thread>
 #include <unordered_set>
+//#include <iostream>
 
 #include "singa/core/device.h"
 #include "singa/utils/safe_queue.h"
@@ -228,6 +229,60 @@ void Graph::Debug() {
   printf("%s", ss.str().c_str());
 }
 
+void Graph::PrintTimeProfiling() {
+  std::stringstream ss;
+
+  // verbosity level: 1 -> forward and backward propagation time
+  if (device_->verbosity() == 1) {
+    bool forward = true;
+    float forward_time = 0;
+    float backward_time = 0;
+    float time_elapsed;
+
+    for (size_t i = 0; i < nodes_.size(); ++i)
+      if (nodes_[i]->time_elapsed() > 0) {
+        if (forward == true)
+          // check the op of cross entropy backward, after that are backward ops
+          if (nodes_[i]->op_name().find("Backward") != std::string::npos)
+            forward = false;
+        // when forward becomes false, it starts the backward propagation
+
+        time_elapsed = (nodes_[i]->time_elapsed()) / (nodes_[i]->iteration());
+
+        // ss << forward_time << " , " << backward_time << std::endl;
+
+        if (forward == true)
+          forward_time += time_elapsed;
+        else
+          backward_time += time_elapsed;
+      }
+    ss << std::endl << "Time Profiling:" << std::endl;
+    ss << "Forward Propagation Time : " << forward_time << " sec" << std::endl;
+    ss << "Backward Propagation Time : " << backward_time << " sec"
+       << std::endl;
+  }
+
+  // verbosity level: 2 -> each operation time (OP_ID, operation name, time)
+  if (device_->verbosity() == 2) {
+    ss << std::endl << "Time Profiling:" << std::endl;
+    for (size_t i = 0; i < nodes_.size(); ++i)
+      if (nodes_[i]->time_elapsed() > 0)
+        ss << "OP_ID" << nodes_[i]->id_ << ". " << nodes_[i]->op_name() << " : "
+           << (nodes_[i]->time_elapsed()) / (nodes_[i]->iteration()) << " sec"
+           << std::endl;
+  }
+
+  printf("%s", ss.str().c_str());
+}
+
+void Graph::TimeProfilingDoExec(Node *curNode) {
+  if (device_->verbosity() > 0 && curNode->op_name_ != "Sync")
+    curNode->time_elapsed_inc(
+        device_->TimeProfilingDoExec(std::move(curNode->op_), 0));
+  else
+    device_->DoExec(std::move(curNode->op_), 0);
+}
+
 void Graph::RunGraph() {
   in_serial_ = false;
   if (dirty_) Analyze();
@@ -247,7 +302,7 @@ void Graph::RunGraph() {
     int curIndex = curNode->id_;
 
     // step 2: execute the operation
-    device_->DoExec(std::move(curNode->op_), 0);
+    TimeProfilingDoExec(curNode);
 
     // step 3: release some blocks' data that won't be used later
     for (auto it : free_blocks_[curIndex]) {
@@ -277,7 +332,7 @@ void Graph::RunInSerial() {
     Node *curNode = nodes_[i];
 
     // step 1: execute the operation
-    device_->DoExec(std::move(curNode->op_), 0);
+    TimeProfilingDoExec(curNode);
 
     // step 2: release some blocks' data that won't be used later
     for (auto it : free_blocks_[i]) {
@@ -294,18 +349,18 @@ void Graph::RunInSerial() {
 }
 
 void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,
-                         const BlockVec &write_blocks) {
+                         const BlockVec &write_blocks, string op_name) {
   dirty_ = true;
 
   // if the size of both read_blocks and write_blocks is zero,
   // this operation is used for synchronization
   if (read_blocks.size() == 0 && write_blocks.size() == 0) {
-    AddSyncOp(std::move(op));
+    AddSyncOp(std::move(op), op_name);
     return;
   }
 
   // create new node
-  Node *node = new Node(nodes_.size(), std::move(op));
+  Node *node = new Node(nodes_.size(), std::move(op), op_name);
 
   // create edges for read_blocks
   for (size_t i = 0; i < read_blocks.size(); ++i) {
@@ -378,9 +433,9 @@ void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,
   nodes_.push_back(node);
 }
 
-void Graph::AddSyncOp(function<void(Context *)> &&op) {
+void Graph::AddSyncOp(function<void(Context *)> &&op, string op_name) {
   // create new node
-  Node *node = new Node(nodes_.size(), std::move(op));
+  Node *node = new Node(nodes_.size(), std::move(op), op_name);
 
   for (size_t i = 0; i < write_blocks_.size(); ++i) {
     Block *blk = write_blocks_[i];

--- a/src/io/communicator.cc
+++ b/src/io/communicator.cc
@@ -186,7 +186,7 @@ void Communicator::wait() {
         CUDA_CHECK(cudaEventRecord(event, c2));
         CUDA_CHECK(cudaStreamWaitEvent(NULL, event, 0));
       },
-      blocks_, blocks_);
+      blocks_, blocks_, "wait");
 }
 
 Communicator::~Communicator() {
@@ -238,7 +238,7 @@ void Communicator::fusedSynch(vector<Tensor> &t, bool send) {
             sendBuffOffset += t[i].Size();
           }
         },
-        prev_blocks_, blocks_);
+        prev_blocks_, blocks_, "fusedSynch_Filling");
   } else {
     // send the tensors in the buffer
     device_->Exec(
@@ -266,7 +266,7 @@ void Communicator::fusedSynch(vector<Tensor> &t, bool send) {
             offset += t[i].Size();
           }
         },
-        blocks_, blocks_);
+        blocks_, blocks_, "fusedSynch_Transfer");
   }
 }
 
@@ -283,7 +283,7 @@ void Communicator::synch(Tensor &t) {
         void *addr = t.block()->mutable_data();
         allReduce(t.Size(), addr, addr, ncclFloat);
       },
-      {t.block()}, {t.block()});
+      {t.block()}, {t.block()}, "synch");
 }
 
 void Communicator::fusedSynchHalf(vector<Tensor> &t, bool send) {
@@ -312,7 +312,7 @@ void Communicator::fusedSynchHalf(vector<Tensor> &t, bool send) {
             offset += t[i].Size();
           }
         },
-        prev_blocks_, blocks_);
+        prev_blocks_, blocks_, "fusedSynchHalf_filling");
   } else {
     // send the tensors in the buffer
     device_->Exec(
@@ -346,7 +346,7 @@ void Communicator::fusedSynchHalf(vector<Tensor> &t, bool send) {
             offset += t[i].Size();
           }
         },
-        blocks_, blocks_);
+        blocks_, blocks_, "fusedSynchHalf_transfer");
   }
 }
 
@@ -378,7 +378,7 @@ void Communicator::synchHalf(Tensor &t) {
 
         cuda::half2float(t.Size(), fusedRecvBuffHalf, addr, c2);
       },
-      blocks_, blocks_);
+      blocks_, blocks_, "synchHalf");
 }
 
 void Communicator::sparsification(Tensor &t, Tensor &accumulation,
@@ -390,7 +390,7 @@ void Communicator::sparsification(Tensor &t, Tensor &accumulation,
       [=](Context *ctx) mutable {
         _sparsification(t, &accumulation, sparsThreshold, topK);
       },
-      blocks_, blocks_);
+      blocks_, blocks_, "sparsification");
 }
 
 void Communicator::sparsification(Tensor &t, float sparsThreshold, bool topK) {
@@ -400,7 +400,7 @@ void Communicator::sparsification(Tensor &t, float sparsThreshold, bool topK) {
       [=](Context *ctx) mutable {
         _sparsification(t, (Tensor *)NULL, sparsThreshold, topK);
       },
-      blocks_, blocks_);
+      blocks_, blocks_, "sparsification");
 }
 
 void Communicator::_sparsification(Tensor &t, Tensor *accumulation,
@@ -446,7 +446,7 @@ void Communicator::fusedSparsification(vector<Tensor> &t, Tensor &accumulation,
       [=](Context *ctx) mutable {
         _fusedSparsification(t, &accumulation, sparsThreshold, topK);
       },
-      blocks_, blocks_);
+      blocks_, blocks_, "fusedSparsification");
 }
 
 void Communicator::fusedSparsification(vector<Tensor> &t, float sparsThreshold,
@@ -459,7 +459,7 @@ void Communicator::fusedSparsification(vector<Tensor> &t, float sparsThreshold,
       [=](Context *ctx) mutable {
         _fusedSparsification(t, (Tensor *)NULL, sparsThreshold, topK);
       },
-      blocks_, blocks_);
+      blocks_, blocks_, "fusedSparsification");
 }
 
 void Communicator::_fusedSparsification(vector<Tensor> &t, Tensor *accumulation,

--- a/src/model/layer/cudnn_activation.cc
+++ b/src/model/layer/cudnn_activation.cc
@@ -81,7 +81,7 @@ const Tensor CudnnActivation::Forward(int flag, const Tensor& input) {
     CUDNN_CHECK(cudnnActivationForward(
         ctx->cudnn_handle, this->acti_desc_, &alpha, this->desc_,
         inblock->data(), &beta, this->desc_, outblock->mutable_data()));
-  }, {input.block()}, {output.block()});
+  }, {input.block()}, {output.block()}, "cudnnActivationForward");
   if (flag & kTrain) {
     if (cudnn_mode_ == CUDNN_ACTIVATION_SIGMOID ||
         cudnn_mode_ == CUDNN_ACTIVATION_TANH) {
@@ -111,7 +111,7 @@ const std::pair<Tensor, vector<Tensor>> CudnnActivation::Backward(
         ctx->cudnn_handle, this->acti_desc_, &alpha, this->desc_,
         yblock->data(), this->desc_, dyblock->data(), this->desc_,
         xblock->data(), &beta, this->desc_, dxblock->mutable_data()));
-  }, {grad.block(), inout.block()}, {dx.block()});
+  }, {grad.block(), inout.block()}, {dx.block()}, "cudnnActivationBackward");
   return std::make_pair(dx, param_grad);
 }
 }  // namespace singa

--- a/src/model/layer/cudnn_convolution.cc
+++ b/src/model/layer/cudnn_convolution.cc
@@ -197,7 +197,7 @@ const Tensor CudnnConvolution::Forward(int flag, const Tensor &input) {
                             this->workspace_.block()->mutable_data(),
                             this->workspace_count_ * sizeof(float), &beta,
                             this->y_desc_, outblock->mutable_data());
-  }, {input.block(), weight_.block()}, {output.block()}, workspace_.block());
+  }, {input.block(), weight_.block()}, {output.block(), workspace_.block()});
 
   if (bias_term_) {
     output.device()->Exec([output, this](Context * ctx) {

--- a/src/model/layer/cudnn_dropout.cc
+++ b/src/model/layer/cudnn_dropout.cc
@@ -70,7 +70,7 @@ const Tensor CudnnDropout::Forward(int flag, const Tensor& input) {
     if (!has_init_cudnn_) {
       input.device()->Exec([size, dtype, this, dev](Context* ctx) {
           this->InitCudnn(size, dtype, dev, ctx);
-          }, {}, {this->state_.block()});
+          }, {}, {this->state_.block()}, "InitCudnn");
     } else {
       int n, c, h, w, s;
       cudnnDataType_t type;
@@ -79,7 +79,7 @@ const Tensor CudnnDropout::Forward(int flag, const Tensor& input) {
       if (size != static_cast<size_t>(w))
         input.device()->Exec([size, dtype, this, dev](Context* ctx) {
             this->InitCudnn(size, dtype, dev, ctx);
-            }, {}, {this->state_.block()});
+            }, {}, {this->state_.block()}, "InitCudnn");
     }
     Tensor output;
     output.ResetLike(input);
@@ -90,7 +90,7 @@ const Tensor CudnnDropout::Forward(int flag, const Tensor& input) {
                           inblock->data(), this->y_desc_,
                           outblock->mutable_data(), mblock->mutable_data(),
                           this->reserve_size_);
-    }, {input.block()}, {output.block(), mask_.block()});
+    }, {input.block()}, {output.block(), mask_.block()}, "cudnnDropoutForward");
     return output;
   } else {
     return input;
@@ -110,7 +110,7 @@ const std::pair<Tensor, vector<Tensor>> CudnnDropout::Backward(
                            dyblock->data(), this->x_desc_,
                            dxblock->mutable_data(), mblock->mutable_data(),
                            this->reserve_size_);
-    }, {grad.block(), mask_.block()}, {dx.block()});
+    }, {grad.block(), mask_.block()}, {dx.block()}, "cudnnDropoutBackward");
   } else {
     LOG(ERROR) << "Do not call backward for evaluation phase";
   }

--- a/src/model/operation/batchnorm.cc
+++ b/src/model/operation/batchnorm.cc
@@ -115,7 +115,7 @@ Tensor CpuBatchNormForwardInference(const BatchNormHandle& bnh, const Tensor& x,
         ctx->dnnl_stream.wait();
       },
       {x.block(), w.block(), running_mean.block(), running_var.block()},
-      {y.block(), running_mean.block(), running_var.block()});
+      {y.block(), running_mean.block(), running_var.block()}, "CpuBatchNormForwardInference");
 
   return y;
 }
@@ -173,7 +173,7 @@ const std::vector<Tensor> CpuBatchNormForwardTraining(
       },
       {x.block(), w.block(), running_mean.block(), running_var.block()},
       {y.block(), running_mean.block(), running_var.block(), mean.block(),
-       var.block()});
+       var.block()}, "CpuBatchNormForwardTraining");
 
   return {y, mean, var};
 }
@@ -238,7 +238,7 @@ const std::vector<Tensor> CpuBatchNormBackwardx(
         ctx->dnnl_stream.wait();
       },
       {x.block(), dy.block(), mean.block(), var.block(), w.block(), y.block()},
-      {dx.block(), dw.block()});
+      {dx.block(), dw.block()}, "CpuBatchNormBackwardx");
 
   singa::Tensor dbnScale(bnScale.shape());
   CopyDataToFrom(&dbnScale, dw, bnScale.Size(), 0, 0);
@@ -323,7 +323,7 @@ const std::vector<Tensor> GpuBatchNormForwardTraining(
       {input.block(), bnScale.block(), bnBias.block(), running_mean.block(),
        running_var.block()},
       {output.block(), running_mean.block(), running_var.block(), mean.block(),
-       var.block()});
+       var.block()}, "GpuBatchNormForwardTraining");
   if (cbnh.is_2d) output.Reshape(Shape{shape.at(0), shape.at(1)});
   return {output, mean, var};
 }
@@ -361,7 +361,7 @@ Tensor GpuBatchNormForwardInference(const CudnnBatchNormHandle& cbnh,
       },
       {input.block(), bnScale.block(), bnBias.block(), running_mean.block(),
        running_var.block()},
-      {output.block()});
+      {output.block()}, "GpuBatchNormForwardInference");
   return output;
 }
 
@@ -396,7 +396,7 @@ const std::vector<Tensor> GpuBatchNormBackward(
             epsilon, mean.block()->data(), var.block()->data()));
       },
       {x.block(), dy.block(), bnScale.block(), mean.block(), var.block()},
-      {dx.block(), dbnScale.block(), dbnBias.block()});
+      {dx.block(), dbnScale.block(), dbnBias.block()}, "GpuBatchNormBackward");
 
   if (cbnh.is_2d) dx.Reshape(Shape{dx.shape().at(0), dx.shape().at(1)});
 

--- a/src/model/operation/convolution.cc
+++ b/src/model/operation/convolution.cc
@@ -185,7 +185,7 @@ Tensor CpuConvForward(const Tensor &x, Tensor &W, Tensor &b,
         // synchronize stream
         s.wait();
       },
-      {x.block(), W.block(), b.block()}, {output.block()});
+      {x.block(), W.block(), b.block()}, {output.block()}, "CpuConvForward");
 
   return output;
 #else   // cpp naive
@@ -279,7 +279,7 @@ Tensor CpuConvBackwardx(const Tensor &dy, Tensor &W, const Tensor &x,
                       {DNNL_ARG_DIFF_SRC, conv_user_src_memory}});
         ctx->dnnl_stream.wait();
       },
-      {x.block(), dy.block(), W.block()}, {dx.block()});
+      {x.block(), dy.block(), W.block()}, {dx.block()}, "CpuConvBackwardx");
 
   return dx;
 
@@ -372,7 +372,7 @@ Tensor CpuConvBackwardW(const Tensor &dy, const Tensor &x, const Tensor &W,
                       {DNNL_ARG_DIFF_BIAS, conv_diff_bias_memory}});
         ctx->dnnl_stream.wait();
       },
-      {x.block(), dy.block(), W.block()}, {dW.block(), ch.db->block()});
+      {x.block(), dy.block(), W.block()}, {dW.block(), ch.db->block()}, "CpuConvBackwardW");
 
   return dW;
 #else   // native cpp
@@ -598,7 +598,7 @@ Tensor GpuConvForward(const Tensor &x, const Tensor &W, const Tensor &b,
                                 cch.workspace_count * sizeof(float), &beta,
                                 cch.y_desc, outblock->mutable_data());
       },
-      {x.block(), W.block()}, {output.block(), cch.workspace.block()});
+      {x.block(), W.block()}, {output.block(), cch.workspace.block()}, "cudnnConvForward");
 
   if (cch.bias_term) {
     Tensor outputFake(output);
@@ -610,7 +610,7 @@ Tensor GpuConvForward(const Tensor &x, const Tensor &W, const Tensor &b,
                          bblock->data(), &beta, cch.y_desc,
                          outblock->mutable_data());
         },
-        {output.block(), b.block()}, {output.block()});
+        {output.block(), b.block()}, {output.block()}, "cudnnAddTensor");
   }
 
   return output;
@@ -634,7 +634,7 @@ Tensor GpuConvBackwardx(const Tensor &dy, const Tensor &W, const Tensor &x,
             cch.workspace_count * sizeof(float), &beta, cch.x_desc,
             dxblock->mutable_data());
       },
-      {dy.block(), W.block()}, {dx.block(), cch.workspace.block()});
+      {dy.block(), W.block()}, {dx.block(), cch.workspace.block()}, "cudnnConvolutionBackwardData");
 
   return dx;
 }
@@ -658,7 +658,7 @@ Tensor GpuConvBackwardW(const Tensor &dy, const Tensor &x, const Tensor &W,
             cch.workspace_count * sizeof(float), &beta, cch.filter_desc,
             dwblock->mutable_data());
       },
-      {dy.block(), x.block()}, {dW.block(), cch.workspace.block()});
+      {dy.block(), x.block()}, {dW.block(), cch.workspace.block()}, "cudnnConvolutionBackwardFilter");
 
   return dW;
 }
@@ -679,7 +679,7 @@ Tensor GpuConvBackwardb(const Tensor &dy, const Tensor &b,
                                      dyblock->data(), &beta, cch.bias_desc,
                                      dbblock->mutable_data());
       },
-      {dy.block()}, {db.block()});
+      {dy.block()}, {db.block()}, "cudnnConvolutionBackwardBias");
 
   return db;
 }

--- a/src/model/operation/pooling.cc
+++ b/src/model/operation/pooling.cc
@@ -112,7 +112,7 @@ Tensor CpuPoolingForward(const PoolingHandle &ph, const Tensor &x) {
                                         {DNNL_ARG_WORKSPACE, ph.ws_mem}});
         ctx->dnnl_stream.wait();
       },
-      {x.block()}, {y.block()});
+      {x.block()}, {y.block()}, "CpuPoolingForward");
 
   return y;
 }
@@ -139,7 +139,7 @@ Tensor CpuPoolingBackward(const PoolingHandle &ph, const Tensor &grad,
                                         {DNNL_ARG_WORKSPACE, ph.ws_mem}});
         ctx->dnnl_stream.wait();
       },
-      {x.block(), y.block(), grad.block()}, {in_grad.block()});
+      {x.block(), y.block(), grad.block()}, {in_grad.block()}, "CpuPoolingBackward");
 
   return in_grad;
 }
@@ -199,7 +199,7 @@ Tensor GpuPoolingForward(const CudnnPoolingHandle &cph, const Tensor &x) {
                             cph.x_desc, x.block()->data(), &beta, cph.y_desc,
                             output.block()->mutable_data());
       },
-      {x.block()}, {output.block()});
+      {x.block()}, {output.block()}, "GpuPoolingForward");
 
   return output;
 }
@@ -220,7 +220,7 @@ Tensor GpuPoolingBackward(const CudnnPoolingHandle &cph, const Tensor &dy,
                              dy.block()->data(), cph.x_desc, x.block()->data(),
                              &beta, cph.x_desc, dx.block()->mutable_data());
       },
-      {dy.block(), y.block(), x.block()}, {dx.block()});
+      {dy.block(), y.block(), x.block()}, {dx.block()}, "GpuPoolingBackward");
 
   return dx;
 };

--- a/test/singa/test_cpp_cpu.cc
+++ b/test/singa/test_cpp_cpu.cc
@@ -42,7 +42,7 @@ TEST(CppCPU, Exec) {
   CppCPU dev;
   Block* b = dev.NewBlock(4);
   int x = 1, y = 3, z = 0;
-  dev.Exec([x, y, &z](singa::Context* ctx) { z = x + y; }, {b}, {b}, false);
+  dev.Exec([x, y, &z](singa::Context* ctx) { z = x + y; }, {b}, {b});
   EXPECT_EQ(x + y, z);
   dev.FreeBlock(b);
 }


### PR DESCRIPTION
Time Profiling for single GPU:
verbosity level: 0 (default) -> no logging
verbosity level: 1 -> forward and backward propagation time 
verbosity level: 2 -> each operation time (OP_ID, operation name, time)
The time is displayed as the average per iteration.

```
root@831960763a12:~/dcsysh/singa/examples/cnn# python3 train.py cnn mnist --verbosity 1
Starting Epoch 0:
Training loss = 578.907959, training accuracy = 0.796141
Evaluation accuracy = 0.937400, Elapsed Time = 5.622292s
Starting Epoch 1:
Training loss = 232.124695, training accuracy = 0.922609
Evaluation accuracy = 0.962841, Elapsed Time = 5.603526s
Starting Epoch 2:
Training loss = 167.437912, training accuracy = 0.944220
Evaluation accuracy = 0.971855, Elapsed Time = 5.422868s
Starting Epoch 3:
Training loss = 138.634125, training accuracy = 0.953392
Evaluation accuracy = 0.966747, Elapsed Time = 5.760310s
Starting Epoch 4:
Training loss = 117.458504, training accuracy = 0.961096
Evaluation accuracy = 0.973057, Elapsed Time = 5.756212s
Starting Epoch 5:
Training loss = 104.992790, training accuracy = 0.965198
Evaluation accuracy = 0.979267, Elapsed Time = 5.637915s
Starting Epoch 6:
Training loss = 96.263885, training accuracy = 0.967249
Evaluation accuracy = 0.980369, Elapsed Time = 5.753364s
Starting Epoch 7:
Training loss = 89.073364, training accuracy = 0.970051
Evaluation accuracy = 0.975561, Elapsed Time = 5.477089s
Starting Epoch 8:
Training loss = 82.311523, training accuracy = 0.972385
Evaluation accuracy = 0.980369, Elapsed Time = 4.668906s
Starting Epoch 9:
Training loss = 78.408806, training accuracy = 0.974270
Evaluation accuracy = 0.979968, Elapsed Time = 3.887881s

Time Profiling:
Forward Propagation Time : 0.00129212 sec
Backward Propagation Time : 0.00195529 sec
root@831960763a12:~/dcsysh/singa/examples/cnn# python3 train.py cnn mnist --verbosity 2
Starting Epoch 0:
Training loss = 578.907959, training accuracy = 0.796141
Evaluation accuracy = 0.937400, Elapsed Time = 4.777571s
Starting Epoch 1:
Training loss = 232.124695, training accuracy = 0.922609
Evaluation accuracy = 0.962841, Elapsed Time = 5.224710s
Starting Epoch 2:
Training loss = 167.437912, training accuracy = 0.944220
Evaluation accuracy = 0.971855, Elapsed Time = 5.266937s
Starting Epoch 3:
Training loss = 138.634125, training accuracy = 0.953392
Evaluation accuracy = 0.966747, Elapsed Time = 5.233795s
Starting Epoch 4:
Training loss = 117.458504, training accuracy = 0.961096
Evaluation accuracy = 0.973057, Elapsed Time = 5.114792s
Starting Epoch 5:
Training loss = 104.992790, training accuracy = 0.965198
Evaluation accuracy = 0.979267, Elapsed Time = 5.324732s
Starting Epoch 6:
Training loss = 96.263885, training accuracy = 0.967249
Evaluation accuracy = 0.980369, Elapsed Time = 5.413473s
Starting Epoch 7:
Training loss = 89.073364, training accuracy = 0.970051
Evaluation accuracy = 0.975561, Elapsed Time = 5.202558s
Starting Epoch 8:
Training loss = 82.311523, training accuracy = 0.972385
Evaluation accuracy = 0.980369, Elapsed Time = 5.240168s
Starting Epoch 9:
Training loss = 78.408806, training accuracy = 0.974270
Evaluation accuracy = 0.979968, Elapsed Time = 5.435664s

Time Profiling:
OP_ID0. cudnnConvForward : 0.000436663 sec
OP_ID1. cudnnAddTensor : 1.84035e-05 sec
OP_ID2. ReLU : 1.65394e-05 sec
OP_ID3. GpuPoolingForward : 1.69464e-05 sec
OP_ID4. cudnnConvForward : 7.17674e-05 sec
OP_ID5. cudnnAddTensor : 1.29785e-05 sec
OP_ID6. ReLU : 1.36852e-05 sec
OP_ID7. GpuPoolingForward : 1.5691e-05 sec
OP_ID8. GEMM : 3.60804e-05 sec
OP_ID9. SetValue : 0.00043388 sec
OP_ID10. GEMM : 2.06141e-05 sec
OP_ID11. ReLU : 1.20454e-05 sec
OP_ID12. GEMM : 2.70016e-05 sec
OP_ID13. SetValue : 0.000404889 sec
OP_ID14. GEMM : 1.56241e-05 sec
OP_ID16. SoftMax : 1.84867e-05 sec
OP_ID17. ComputeCrossEntropy : 1.24012e-05 sec
OP_ID18. SetValue : 7.12093e-05 sec
OP_ID19. SumAll : 2.48265e-05 sec
OP_ID20. Div : 1.02195e-05 sec
OP_ID22. CopyDataToFrom : 1.58324e-05 sec
OP_ID23. SoftmaxCrossEntropyBackward : 1.12932e-05 sec
OP_ID24. Div : 8.58751e-06 sec
OP_ID25. SetValue : 4.41526e-05 sec
OP_ID26. GEMV : 1.13555e-05 sec
OP_ID27. Axpy : 9.7881e-06 sec
OP_ID28. EltwiseMult : 2.51771e-05 sec
OP_ID29. Axpy : 8.55843e-06 sec
OP_ID30. Axpy : 9.03056e-06 sec
OP_ID31. GEMM : 1.95876e-05 sec
OP_ID32. GEMM : 1.71203e-05 sec
OP_ID33. Axpy : 9.33386e-06 sec
OP_ID34. EltwiseMult : 1.80905e-05 sec
OP_ID35. Axpy : 9.85235e-06 sec
OP_ID36. Axpy : 1.01951e-05 sec
OP_ID37. ReLUBackward : 1.13822e-05 sec
OP_ID38. SetValue : 1.89965e-05 sec
OP_ID39. GEMV : 1.08617e-05 sec
OP_ID40. Axpy : 9.05562e-06 sec
OP_ID41. EltwiseMult : 1.70098e-05 sec
OP_ID42. Axpy : 9.63604e-06 sec
OP_ID43. Axpy : 1.01054e-05 sec
OP_ID44. GEMM : 2.5537e-05 sec
OP_ID45. GEMM : 1.83094e-05 sec
OP_ID46. Axpy : 1.58145e-05 sec
OP_ID47. EltwiseMult : 2.04723e-05 sec
OP_ID48. Axpy : 1.6055e-05 sec
OP_ID49. Axpy : 2.054e-05 sec
OP_ID50. GpuPoolingBackward : 2.56164e-05 sec
OP_ID51. ReLUBackward : 1.4184e-05 sec
OP_ID52. cudnnConvolutionBackwardData : 7.3398e-05 sec
OP_ID53. cudnnConvolutionBackwardFilter : 7.19914e-05 sec
OP_ID54. cudnnConvolutionBackwardBias : 3.50412e-05 sec
OP_ID55. Axpy : 1.55906e-05 sec
OP_ID56. EltwiseMult : 1.38977e-05 sec
OP_ID57. Axpy : 1.45207e-05 sec
OP_ID58. Axpy : 6.90636e-05 sec
OP_ID59. Axpy : 1.37194e-05 sec
OP_ID60. EltwiseMult : 1.22707e-05 sec
OP_ID61. Axpy : 1.30436e-05 sec
OP_ID62. Axpy : 6.80907e-05 sec
OP_ID63. GpuPoolingBackward : 3.11083e-05 sec
OP_ID64. ReLUBackward : 3.09392e-05 sec
OP_ID65. cudnnConvolutionBackwardData : 6.54513e-05 sec
OP_ID66. cudnnConvolutionBackwardFilter : 9.62518e-05 sec
OP_ID67. cudnnConvolutionBackwardBias : 0.000128262 sec
OP_ID68. Axpy : 8.82783e-05 sec
OP_ID69. EltwiseMult : 1.14388e-05 sec
OP_ID70. Axpy : 4.30799e-05 sec
OP_ID71. Axpy : 1.65033e-05 sec
OP_ID72. Axpy : 7.64395e-05 sec
OP_ID73. EltwiseMult : 9.64545e-06 sec
OP_ID74. Axpy : 3.94519e-05 sec
OP_ID75. Axpy : 1.51809e-05 sec
```