### PR TITLE
SINGA-510 Improvement of Time Profiling Function

### DIFF
--- a/examples/cnn/benchmark.py
+++ b/examples/cnn/benchmark.py
@@ -62,6 +62,7 @@ def train_resnet(DIST=True, graph=True, sequential=False, verbosity=0):
     ty.copy_from_numpy(y)
 
     dev.SetVerbosity(verbosity)
+    dev.SetSkipIteration(5)
 
     # construct the model
     from model import resnet

--- a/examples/cnn/benchmark.py
+++ b/examples/cnn/benchmark.py
@@ -30,7 +30,7 @@ import numpy as np
 from tqdm import trange
 
 
-def train_resnet(DIST=True, graph=True, sequential=False):
+def train_resnet(DIST=True, graph=True, sequential=False, verbosity=0):
 
     # Define the hypermeters good for the train_resnet
     niters = 100
@@ -40,7 +40,7 @@ def train_resnet(DIST=True, graph=True, sequential=False):
     IMG_SIZE = 224
 
     # For distributed training, sequential has better throughput in the current version
-    if DIST:
+    if DIST == True:
         sgd = opt.DistOpt(sgd)
         world_size = sgd.world_size
         local_rank = sgd.local_rank
@@ -60,6 +60,8 @@ def train_resnet(DIST=True, graph=True, sequential=False):
     y = np.random.randint(0, 1000, batch_size, dtype=np.int32)
     tx.copy_from_numpy(x)
     ty.copy_from_numpy(y)
+
+    dev.SetVerbosity(verbosity)
 
     # construct the model
     from model import resnet
@@ -87,7 +89,8 @@ def train_resnet(DIST=True, graph=True, sequential=False):
         print("Throughput = {} per second".format(throughput), flush=True)
         print("TotalTime={}".format(end - start), flush=True)
         print("Total={}".format(titer), flush=True)
-
+    
+    dev.PrintTimeProfiling()
 
 if __name__ == "__main__":
 
@@ -105,7 +108,13 @@ if __name__ == "__main__":
                         action='store_false',
                         help='disable graph',
                         dest='graph')
+    parser.add_argument('--verbosity',
+                        '--log-verbosity',
+                        default=0,
+                        type=int,
+                        help='logging verbosity',
+                        dest='verbosity')
 
     args = parser.parse_args()
 
-    train_resnet(DIST=args.DIST, graph=args.graph)
+    train_resnet(DIST=args.DIST, graph=args.graph, sequential=False, verbosity=args.verbosity)

--- a/examples/cnn/benchmark.py
+++ b/examples/cnn/benchmark.py
@@ -89,8 +89,9 @@ def train_resnet(DIST=True, graph=True, sequential=False, verbosity=0):
         print("Throughput = {} per second".format(throughput), flush=True)
         print("TotalTime={}".format(end - start), flush=True)
         print("Total={}".format(titer), flush=True)
-    
+
     dev.PrintTimeProfiling()
+
 
 if __name__ == "__main__":
 
@@ -117,4 +118,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    train_resnet(DIST=args.DIST, graph=args.graph, sequential=False, verbosity=args.verbosity)
+    train_resnet(DIST=args.DIST,
+                 graph=args.graph,
+                 sequential=False,
+                 verbosity=args.verbosity)

--- a/include/singa/core/device.h
+++ b/include/singa/core/device.h
@@ -124,8 +124,9 @@ class Device {
  protected:
   /// Execute one operation on one executor.
   virtual void DoExec(function<void(Context*)>&& fn, int executor) = 0;
-  virtual float TimeProfilingDoExec(function<void(Context*)>&& fn,
-                                    int executor) = 0;
+  virtual void TimeProfilingDoExec(function<void(Context*)>&& fn,
+                            int executor, Node *node) = 0;
+  virtual void EvaluateTimeElapsed(Node *node) = 0;
 
   virtual void CopyToFrom(void* dst, const void* src, size_t nBytes,
                           CopyDirection direction, Context* ctx) = 0;
@@ -179,8 +180,9 @@ class CppCPU : public Device {
 
  protected:
   void DoExec(function<void(Context*)>&& fn, int executor) override;
-  float TimeProfilingDoExec(function<void(Context*)>&& fn,
-                            int executor) override;
+  void TimeProfilingDoExec(function<void(Context*)>&& fn,
+                            int executor, Node *node) override;
+  void EvaluateTimeElapsed(Node *node) override;
 
   void CopyToFrom(void* dst, const void* src, size_t nBytes,
                   CopyDirection direction, Context* ctx) override;
@@ -211,8 +213,10 @@ class CudaGPU : public Device {
 
  protected:
   void DoExec(function<void(Context*)>&& fn, int executor) override;
-  float TimeProfilingDoExec(function<void(Context*)>&& fn,
-                            int executor) override;
+  void TimeProfilingDoExec(function<void(Context*)>&& fn,
+                            int executor, Node *node) override;
+  void EvaluateTimeElapsed(Node *node) override;
+
   void SyncBeforeCountingTime();
 
   void CopyToFrom(void* dst, const void* src, size_t nBytes,

--- a/include/singa/core/device.h
+++ b/include/singa/core/device.h
@@ -115,11 +115,14 @@ class Device {
   /// verbosity == 1 -> display forward and backward propagation time
   /// verbosity == 2 -> display each operation time (OP_ID, op name, time)
   int verbosity() const { return verbosity_; }
+  /// the number of initial iteration that is skipped for time profiling
+  int skip_iteration() const { return skip_iteration_; }
 
   virtual std::shared_ptr<Device> host() const { return host_; }
 
   void PrintTimeProfiling();
   void SetVerbosity(int verbosity) { verbosity_ = verbosity; };
+  void SetSkipIteration(int skip_iteration) { skip_iteration_ = skip_iteration; };
 
  protected:
   /// Execute one operation on one executor.
@@ -149,6 +152,7 @@ class Device {
   unsigned seed_ = 0;
   bool graph_enabled_ = false;
   int verbosity_ = 0;
+  int skip_iteration_ = 5;
   /// The computational graph
   Graph* graph_ = nullptr;
   /// Programming language type, could be kCpp, kCuda, kOpencl

--- a/include/singa/core/scheduler.h
+++ b/include/singa/core/scheduler.h
@@ -68,6 +68,11 @@ class Node {
   // time profiling
   void time_elapsed_inc(float time) { time_elapsed_ += time; }
 
+#ifdef USE_CUDA
+  cudaEvent_t start_;
+  cudaEvent_t end_;
+#endif  // USE_CUDA
+
  private:
   friend Graph;
 
@@ -78,7 +83,7 @@ class Node {
 
   string op_name_;
   float time_elapsed_ = 0;
- 
+
 };
 
 class Edge {
@@ -160,7 +165,8 @@ class Graph {
   const NodeVec &begin_nodes() const { return begin_nodes_; }
   const std::vector<NodeVec> &next_nodes() const { return next_nodes_; }
   const std::vector<BlockVec> &free_blocks() const { return free_blocks_; }
-  float iteration() const { return iteration_; }
+  int iteration() const { return iteration_; }
+  int skip_iteration() const { return skip_iteration_; }
 
   Node *node(const size_t idx) const;
   Edge *edge(const size_t idx) const;
@@ -173,6 +179,7 @@ class Graph {
   const BlockVec &free_blocks(const size_t idx) const;
 
   void PrintTimeProfiling();
+  void EvaluateTimeElapsed();
 
  private:
   void Analyze();

--- a/include/singa/core/scheduler.h
+++ b/include/singa/core/scheduler.h
@@ -22,18 +22,18 @@
 #include <condition_variable>
 #include <functional>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
-#include <string>
 
 #include "singa/core/common.h"
 #include "singa/utils/safe_queue.h"
 
 using std::function;
+using std::string;
 using std::unordered_map;
 using std::vector;
-using std::string;
 
 namespace singa {
 
@@ -53,7 +53,8 @@ enum BlockType { kUnknow, kInput, kParam, kInter, kEnd };
 
 class Node {
  public:
-  Node(int id, OpFunc &&op, string op_name) : id_(id), op_(std::move(op)), op_name_(op_name) {}
+  Node(int id, OpFunc &&op, string op_name)
+      : id_(id), op_(std::move(op)), op_name_(op_name) {}
 
   void AddInEdge(Edge *in_edge);
   void AddOutEdge(Edge *out_edge);
@@ -64,7 +65,7 @@ class Node {
   const EdgeVec &in_edges() const { return in_edges_; }
   const EdgeVec &out_edges() const { return out_edges_; }
   float time_elapsed() const { return time_elapsed_; }
-  
+
   // time profiling
   void time_elapsed_inc(float time) { time_elapsed_ += time; }
 

--- a/include/singa/core/scheduler.h
+++ b/include/singa/core/scheduler.h
@@ -204,6 +204,7 @@ class Graph {
   std::vector<NodeVec> next_nodes_;
   std::vector<BlockVec> free_blocks_;
   int iteration_ = 0;
+  int skip_iteration_ = 5;
 
   SafeQueue<int> free_queue_;
 };

--- a/include/singa/core/scheduler.h
+++ b/include/singa/core/scheduler.h
@@ -69,11 +69,6 @@ class Node {
   // time profiling
   void time_elapsed_inc(float time) { time_elapsed_ += time; }
 
-#ifdef USE_CUDA
-  cudaEvent_t start_;
-  cudaEvent_t end_;
-#endif  // USE_CUDA
-
  private:
   friend Graph;
 
@@ -85,6 +80,11 @@ class Node {
   string op_name_;
   float time_elapsed_ = 0;
 
+#ifdef USE_CUDA
+  cudaEvent_t start_;
+  cudaEvent_t end_;
+  friend class CudaGPU;
+#endif  // USE_CUDA
 };
 
 class Edge {
@@ -167,7 +167,6 @@ class Graph {
   const std::vector<NodeVec> &next_nodes() const { return next_nodes_; }
   const std::vector<BlockVec> &free_blocks() const { return free_blocks_; }
   int iteration() const { return iteration_; }
-  int skip_iteration() const { return skip_iteration_; }
 
   Node *node(const size_t idx) const;
   Edge *edge(const size_t idx) const;
@@ -212,7 +211,6 @@ class Graph {
   std::vector<NodeVec> next_nodes_;
   std::vector<BlockVec> free_blocks_;
   int iteration_ = 0;
-  int skip_iteration_ = 5;
 
   SafeQueue<int> free_queue_;
 };

--- a/src/api/core_device.i
+++ b/src/api/core_device.i
@@ -55,6 +55,7 @@ class Device {
   void EnableGraph(bool enable);
   void PrintTimeProfiling();
   void SetVerbosity(int verbosity);
+  void SetSkipIteration(int skip_iteration);
   static void EnableLazyAlloc(bool enbale);
 };
 

--- a/src/core/device/cpp_cpu.cc
+++ b/src/core/device/cpp_cpu.cc
@@ -40,15 +40,17 @@ void CppCPU::DoExec(function<void(Context*)>&& fn, int executor) {
   fn(&ctx_);
 }
 
-float CppCPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor) {
+void CppCPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor, Node *node) {
   CHECK_EQ(executor, 0);
 
   auto t_start = std::chrono::high_resolution_clock::now();
   fn(&ctx_);
   std::chrono::duration<float> duration =
       std::chrono::high_resolution_clock::now() - t_start;
-  return duration.count();
+  node->time_elapsed_inc(duration.count());
 }
+
+void CppCPU::EvaluateTimeElapsed(Node *node) {}
 
 void* CppCPU::Malloc(int size) {
   if (size > 0) {

--- a/src/core/device/cpp_cpu.cc
+++ b/src/core/device/cpp_cpu.cc
@@ -40,7 +40,8 @@ void CppCPU::DoExec(function<void(Context*)>&& fn, int executor) {
   fn(&ctx_);
 }
 
-void CppCPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor, Node *node) {
+void CppCPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor,
+                                 Node* node) {
   CHECK_EQ(executor, 0);
 
   auto t_start = std::chrono::high_resolution_clock::now();
@@ -50,7 +51,7 @@ void CppCPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor, No
   node->time_elapsed_inc(duration.count());
 }
 
-void CppCPU::EvaluateTimeElapsed(Node *node) {}
+void CppCPU::EvaluateTimeElapsed(Node* node) {}
 
 void* CppCPU::Malloc(int size) {
   if (size > 0) {

--- a/src/core/device/cuda_gpu.cc
+++ b/src/core/device/cuda_gpu.cc
@@ -112,7 +112,6 @@ float CudaGPU::TimeProfilingDoExec(function<void(Context*)>&& fn, int executor) 
 
     cudaEventRecord(start, ctx_.stream);
     fn(&ctx_);
-    cudaDeviceSynchronize();
     cudaEventRecord(end, ctx_.stream);
 
     cudaEventSynchronize(end);

--- a/src/core/device/device.cc
+++ b/src/core/device/device.cc
@@ -59,14 +59,18 @@ void Device::RunGraph(bool serial) {
     graph_->RunGraph();
   }
 
+  //if ((verbosity_ > 0)  && (graph_->iteration() >= graph_->skip_iteration()))
+  //{
+    //printf("here");
+    //graph_->EvaluateTimeElapsed();
+  //}
+
   // graph_->Debug();
 
   graph_enabled_ = previous_state;
 }
 
-void Device::PrintTimeProfiling() {
-   graph_->PrintTimeProfiling();
-}
+void Device::PrintTimeProfiling() { graph_->PrintTimeProfiling(); }
 
 // Todo(Wangwei) Get Block From The Memory manager
 Block* Device::NewBlock(int size) {

--- a/src/core/device/device.cc
+++ b/src/core/device/device.cc
@@ -59,10 +59,10 @@ void Device::RunGraph(bool serial) {
     graph_->RunGraph();
   }
 
-  //if ((verbosity_ > 0)  && (graph_->iteration() >= graph_->skip_iteration()))
+  // if ((verbosity_ > 0)  && (graph_->iteration() >= graph_->skip_iteration()))
   //{
-    //printf("here");
-    //graph_->EvaluateTimeElapsed();
+  // printf("here");
+  // graph_->EvaluateTimeElapsed();
   //}
 
   // graph_->Debug();

--- a/src/core/device/device.cc
+++ b/src/core/device/device.cc
@@ -59,12 +59,6 @@ void Device::RunGraph(bool serial) {
     graph_->RunGraph();
   }
 
-  // if ((verbosity_ > 0)  && (graph_->iteration() >= graph_->skip_iteration()))
-  //{
-  // printf("here");
-  // graph_->EvaluateTimeElapsed();
-  //}
-
   // graph_->Debug();
 
   graph_enabled_ = previous_state;

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -250,7 +250,7 @@ void Graph::PrintTimeProfiling() {
         // when forward becomes false, it starts the backward propagation
 
         time_elapsed =
-            (nodes_[i]->time_elapsed()) / (iteration_ - skip_iteration_);
+            (nodes_[i]->time_elapsed()) / (iteration_ - device_->skip_iteration());
 
         // ss << forward_time << " , " << backward_time << std::endl;
 
@@ -279,14 +279,14 @@ void Graph::PrintTimeProfiling() {
 
 void Graph::TimeProfilingDoExec(Node *curNode) {
   if ((device_->verbosity() > 0) && (curNode->op_name_ != "Sync") &&
-      (iteration_ >= skip_iteration_))
+      (iteration_ >= device_->skip_iteration()))
     device_->TimeProfilingDoExec(std::move(curNode->op_), 0, curNode);
   else
     device_->DoExec(std::move(curNode->op_), 0);
 }
 
 void Graph::EvaluateTimeElapsed() {
-  if ((device_->verbosity() > 0) && (iteration_ >= skip_iteration_)) {
+  if ((device_->verbosity() > 0) && (iteration_ >= device_->skip_iteration())) {
     device_->Sync();
     for (size_t i = 0; i < nodes_.size(); ++i) {
       Node *curNode = nodes_[i];

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -249,7 +249,7 @@ void Graph::PrintTimeProfiling() {
             forward = false;
         // when forward becomes false, it starts the backward propagation
 
-        time_elapsed = (nodes_[i]->time_elapsed()) / (iteration_);
+        time_elapsed = (nodes_[i]->time_elapsed()) / (iteration_ - skip_iteration_);
 
         // ss << forward_time << " , " << backward_time << std::endl;
 
@@ -270,15 +270,15 @@ void Graph::PrintTimeProfiling() {
     for (size_t i = 0; i < nodes_.size(); ++i)
       if (nodes_[i]->time_elapsed() > 0)
         ss << "OP_ID" << nodes_[i]->id_ << ". " << nodes_[i]->op_name() << " : "
-           << (nodes_[i]->time_elapsed()) / (iteration_) << " sec"
-           << std::endl;
+           << (nodes_[i]->time_elapsed()) / (iteration_) << " sec" << std::endl;
   }
 
   printf("%s", ss.str().c_str());
 }
 
 void Graph::TimeProfilingDoExec(Node *curNode) {
-  if (device_->verbosity() > 0 && curNode->op_name_ != "Sync")
+  if (device_->verbosity() > 0 && curNode->op_name_ != "Sync" &&
+      iteration_ >= skip_iteration_)
     curNode->time_elapsed_inc(
         device_->TimeProfilingDoExec(std::move(curNode->op_), 0));
   else
@@ -327,7 +327,6 @@ void Graph::RunGraph() {
 
   // increment iteration counter
   step();
-
 }
 
 void Graph::RunInSerial() {
@@ -355,7 +354,6 @@ void Graph::RunInSerial() {
 
   // increment iteration counter
   step();
-
 }
 
 void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -104,6 +104,8 @@ void Graph::Reset() {
 
   write_blocks_.clear();
 
+  iteration_ = 0;
+
   dirty_ = false;
 }
 
@@ -249,8 +251,8 @@ void Graph::PrintTimeProfiling() {
             forward = false;
         // when forward becomes false, it starts the backward propagation
 
-        time_elapsed =
-            (nodes_[i]->time_elapsed()) / (iteration_ - device_->skip_iteration());
+        time_elapsed = (nodes_[i]->time_elapsed()) /
+                       (iteration_ - device_->skip_iteration());
 
         // ss << forward_time << " , " << backward_time << std::endl;
 
@@ -286,7 +288,7 @@ void Graph::TimeProfilingDoExec(Node *curNode) {
 }
 
 void Graph::EvaluateTimeElapsed() {
-  if ((device_->verbosity() > 0) && (iteration_ >= device_->skip_iteration())) {
+  if ((device_->verbosity() > 0) && (iteration_ > device_->skip_iteration())) {
     device_->Sync();
     for (size_t i = 0; i < nodes_.size(); ++i) {
       Node *curNode = nodes_[i];
@@ -337,10 +339,9 @@ void Graph::RunGraph() {
     }
   }
 
-  EvaluateTimeElapsed();
-
   // increment iteration counter
   step();
+  EvaluateTimeElapsed();
 }
 
 void Graph::RunInSerial() {
@@ -366,10 +367,9 @@ void Graph::RunInSerial() {
     */
   }
 
-  EvaluateTimeElapsed();
-
   // increment iteration counter
   step();
+  EvaluateTimeElapsed();
 }
 
 void Graph::AddOperation(OpFunc &&op, const BlockVec &read_blocks,

--- a/src/core/scheduler/scheduler.cc
+++ b/src/core/scheduler/scheduler.cc
@@ -287,6 +287,7 @@ void Graph::TimeProfilingDoExec(Node *curNode) {
 
 void Graph::EvaluateTimeElapsed() {
   if ((device_->verbosity() > 0) && (iteration_ >= skip_iteration_)) {
+    device_->Sync();
     for (size_t i = 0; i < nodes_.size(); ++i) {
       Node *curNode = nodes_[i];
       if (curNode->op_name_ != "Sync") {


### PR DESCRIPTION
There are several improvement in the time profiling function
1.  Greatly reduced the measurement overhead: In the new version, we synchronize the cudastream only one time at the end of iteration. The previous version needs to synchronize cudastream whenever it measures each operation, so it introduced time overhead.
2. Can skip the initial iterations for time profiling. It can be set using the function SetSkipIteration, while the default is 5 iterations.
3. Modify the benchmark.py for resnet 50 benchmark time profiling.
