### PR TITLE
Upgrade CUDNN version from 7.3.1 to 7.6.5

### DIFF
--- a/tool/conda/dist/meta.yaml
+++ b/tool/conda/dist/meta.yaml
@@ -21,6 +21,10 @@ package:
   name: singa-dist
   version: {{ environ.get('GIT_DESCRIBE_TAG') }}
 
+source:
+  path: ../../../
+  # git_url: https://github.com/apache/singa.git
+
 requirements:
   run:
     - singa {{ environ.get('GIT_DESCRIBE_TAG') }} cudnn7.6.5_cuda10.0_nccl2.4.8.1_mpich3.3.2_py{{ py }}

--- a/tool/conda/dist/meta.yaml
+++ b/tool/conda/dist/meta.yaml
@@ -23,7 +23,7 @@ package:
 
 requirements:
   run:
-    - singa {{ environ.get('GIT_DESCRIBE_TAG') }} cudnn7.3.1_cuda10.0_nccl2.4.8.1_mpich3.3.2_py{{ py }}
+    - singa {{ environ.get('GIT_DESCRIBE_TAG') }} cudnn7.6.5_cuda10.0_nccl2.4.8.1_mpich3.3.2_py{{ py }}
 
 build:
   number: 0

--- a/tool/conda/docker/cuda10.2/Dockerfile
+++ b/tool/conda/docker/cuda10.2/Dockerfile
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# 18.04 has erros in ssh
+FROM nvidia/cuda:10.2-devel-ubuntu16.04
+
+# install dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        cmake \
+        wget \
+        openssh-server \
+        ca-certificates \
+    && apt-get clean \
+    && apt-get autoremove \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/* \
+    #
+    # install conda, conda-build and anaconda-client
+    #
+    && wget --no-check-certificate https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh \
+    && bash miniconda.sh -b -p /root/miniconda \
+    && /root/miniconda/bin/conda config --set always_yes yes --set changeps1 no \
+    && /root/miniconda/bin/conda update -q conda \
+    && /root/miniconda/bin/conda install -y \
+        conda-build \
+        anaconda-client \
+    && /root/miniconda/bin/conda clean -tipsy \
+    # config ssh service
+    && mkdir /var/run/sshd \
+    && echo 'root:singa' | chpasswd \
+    # for ubuntu 16.04 prohibit
+    && sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    # SSH login fix. Otherwise user is kicked off after login
+    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+    # dump environment variables into files, so that ssh can see also
+    && env | grep _ >> /etc/environment
+
+# Add conda to PATH. Doing this here so other RUN steps can be grouped above
+ENV PATH /root/miniconda/bin:${PATH}
+
+# In nvidia/cuda:10.2-devel-ubuntu16.04, the location of cubas headers moved to another directory
+RUN cp /usr/include/cublas* /usr/local/cuda/include/
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/tool/conda/gpu/meta.yaml
+++ b/tool/conda/gpu/meta.yaml
@@ -26,7 +26,7 @@ source:
 
 requirements:
   run:
-    - singa {{ environ.get('GIT_DESCRIBE_TAG') | replace("-", ".") }} cudnn7.3.1_cuda10.0_py{{ py }}
+    - singa {{ environ.get('GIT_DESCRIBE_TAG') | replace("-", ".") }} cudnn7.6.5_cuda10.0_py{{ py }}
 
 build:
   number: 0

--- a/tool/conda/singa/conda_build_config.yaml
+++ b/tool/conda/singa/conda_build_config.yaml
@@ -25,6 +25,7 @@ cxx_compiler_version:       # [linux]
 CONDA_BUILD_SYSROOT:
     - "/tmp/MacOSX10.9.sdk" # [osx]
 cudnn:                      # [linux]
+    - "7.6.5 cuda10.2_0"    # [environ.get("CUDA")=="10.2"]
     - "7.6.5 cuda10.0_0"    # [environ.get("CUDA")=="10.0"]
     - "7.6.5 cuda9.0_0"     # [environ.get("CUDA")=="9.0"]
 dnnl:
@@ -33,12 +34,16 @@ python:
     - 3.6
     - 3.7
 nccl:
-    - 2.4.8.1
+    - 2.6.4.1               # [environ.get("CUDA")=="10.2"]
+    - 2.4.8.1               # [environ.get("CUDA")=="10.0"]
+    - 2.4.8.1               # [environ.get("CUDA")=="9.0"]
 mpich:
     - 3.3.2
 build_str:
+    - "cudnn7.6.5_cuda10.2"   # [environ.get("CUDA")=="10.2"] && [environ.get("DIST")=="OFF"]
     - "cudnn7.6.5_cuda10.0"   # [environ.get("CUDA")=="10.0"] && [environ.get("DIST")=="OFF"]
     - "cudnn7.6.5_cuda9.0"    # [environ.get("CUDA")=="9.0"] && [environ.get("DIST")=="OFF"]
-    - "cpu"              # [environ.get("CUDA", "")== ""]
+    - "cpu"                   # [environ.get("CUDA", "")== ""]
+    - "cudnn7.6.5_cuda10.2_nccl2.6.4.1_mpich3.3.2"     # [environ.get("CUDA")=="10.2"] && [environ.get("DIST")=="ON"]
     - "cudnn7.6.5_cuda10.0_nccl2.4.8.1_mpich3.3.2"     # [environ.get("CUDA")=="10.0"] && [environ.get("DIST")=="ON"]
-    - "cudnn7.6.5_cuda9.0_nccl2.4.8.1_mpich3.3.2"     # [environ.get("CUDA")=="9.0"] && [environ.get("DIST")=="ON"]
+    - "cudnn7.6.5_cuda9.0_nccl2.4.8.1_mpich3.3.2"      # [environ.get("CUDA")=="9.0"] && [environ.get("DIST")=="ON"]

--- a/tool/conda/singa/conda_build_config.yaml
+++ b/tool/conda/singa/conda_build_config.yaml
@@ -25,8 +25,8 @@ cxx_compiler_version:       # [linux]
 CONDA_BUILD_SYSROOT:
     - "/tmp/MacOSX10.9.sdk" # [osx]
 cudnn:                      # [linux]
-    - "7.3.1 cuda10.0_0"    # [environ.get("CUDA")=="10.0"]
-    - "7.3.1 cuda9.0_0"     # [environ.get("CUDA")=="9.0"]
+    - "7.6.5 cuda10.0_0"    # [environ.get("CUDA")=="10.0"]
+    - "7.6.5 cuda9.0_0"     # [environ.get("CUDA")=="9.0"]
 dnnl:
     - 1.1
 python:
@@ -37,8 +37,8 @@ nccl:
 mpich:
     - 3.3.2
 build_str:
-    - "cudnn7.3.1_cuda10.0"   # [environ.get("CUDA")=="10.0"] && [environ.get("DIST")=="OFF"]
-    - "cudnn7.3.1_cuda9.0"    # [environ.get("CUDA")=="9.0"] && [environ.get("DIST")=="OFF"]
+    - "cudnn7.6.5_cuda10.0"   # [environ.get("CUDA")=="10.0"] && [environ.get("DIST")=="OFF"]
+    - "cudnn7.6.5_cuda9.0"    # [environ.get("CUDA")=="9.0"] && [environ.get("DIST")=="OFF"]
     - "cpu"              # [environ.get("CUDA", "")== ""]
-    - "cudnn7.3.1_cuda10.0_nccl2.4.8.1_mpich3.3.2"     # [environ.get("CUDA")=="10.0"] && [environ.get("DIST")=="ON"]
-    - "cudnn7.3.1_cuda9.0_nccl2.4.8.1_mpich3.3.2"     # [environ.get("CUDA")=="9.0"] && [environ.get("DIST")=="ON"]
+    - "cudnn7.6.5_cuda10.0_nccl2.4.8.1_mpich3.3.2"     # [environ.get("CUDA")=="10.0"] && [environ.get("DIST")=="ON"]
+    - "cudnn7.6.5_cuda9.0_nccl2.4.8.1_mpich3.3.2"     # [environ.get("CUDA")=="9.0"] && [environ.get("DIST")=="ON"]

--- a/tool/docker/devel/ubuntu/cuda10/Dockerfile
+++ b/tool/docker/devel/ubuntu/cuda10/Dockerfile
@@ -18,7 +18,7 @@
 # Change tags to build with different cuda/cudnn versions:
 FROM nvidia/cuda:10.0-devel-ubuntu18.04
 
-ENV CUDNN_VERSION 7.4.2.24
+ENV CUDNN_VERSION 7.6.5.32
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libcudnn7=$CUDNN_VERSION-1+cuda10.0 \

--- a/tool/docker/devel/ubuntu/cuda9/Dockerfile
+++ b/tool/docker/devel/ubuntu/cuda9/Dockerfile
@@ -18,7 +18,7 @@
 # Change tags to build with different cuda/cudnn versions:
 FROM nvidia/cuda:9.0-devel-ubuntu16.04
 
-ENV CUDNN_VERSION 7.4.2.24
+ENV CUDNN_VERSION 7.6.5.32
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libcudnn7=$CUDNN_VERSION-1+cuda9.0 \


### PR DESCRIPTION
I see some other frameworks have updated their cudnn to 7.6.

Our cudnn version is quite old, so I modify the version of cudnn from 7.3.1 to 7.6.5 (in conda env as well as docker env). Therefore, when we do performance analysis, we can base on same/similar version of cudnn.

Meanswhile, the speed seems does not change, compared in panda13 (cuda 10.2).

Test environment: Conda
(i) cudnn 7.3.1
```
(singapy36) dcsysh@panda13:~/singa/examples/cnn$ python3 benchmark.py
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:13<00:00,  7.56it/s]
Throughput = 241.5528073484408 per second
TotalTime=13.247620820999146
Total=0.13247620820999145
```

(ii) cudnn 7.6.5
```
(singapy36cudnn765) dcsysh@panda13:~/singa/examples/cnn$ python benchmark.py
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:13<00:00,  7.55it/s]
Throughput = 241.11137013487107 per second
TotalTime=13.271875143051147
Total=0.13271875143051148
```

This update also means that in the future we may use new features (new APIs) in cudnn provided from cudnn 7.4 to 7.6
https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_765.html#rel_765