### PR TITLE
Fix some GPU test cases by precision setting

### DIFF
--- a/test/python/test_api.py
+++ b/test/python/test_api.py
@@ -129,7 +129,7 @@ class TestAPI(unittest.TestCase):
                 tensor.Tensor(device=dev, data=b_0).data, rm_t.data, rv_t.data)
 
             np.testing.assert_array_almost_equal(
-                y_1, tensor.to_numpy(_cTensor_to_pyTensor(y_2_c)))
+                y_1, tensor.to_numpy(_cTensor_to_pyTensor(y_2_c)), decimal=4)
             np.testing.assert_array_almost_equal(
                 bm_1, tensor.to_numpy(_cTensor_to_pyTensor(bm_2_c)))
             np.testing.assert_array_almost_equal(rm_1, tensor.to_numpy(rm_t))
@@ -183,7 +183,7 @@ class TestAPI(unittest.TestCase):
             #print(tensor.to_numpy(_cTensor_to_pyTensor(y_2_c)))
 
             np.testing.assert_array_almost_equal(
-                y_1, tensor.to_numpy(_cTensor_to_pyTensor(y_2_c)), decimal=5)
+                y_1, tensor.to_numpy(_cTensor_to_pyTensor(y_2_c)), decimal=3)
             return
 
         x_0 = np.array([1, 1, 1, 1, 2, 2, 2, 2, 10, 10, 10, 10, 20, 20, 20, 20],


### PR DESCRIPTION
Here is just a very minor fix of GPU test case, which needs to set the precision of test. 

For instance, the default precision of test is absolute tolerance atol=1e-6 if (we don't pass the argument), which is too tough.

```
root@d05828f767ee:~/dcsysh/singa/test/python# python3 test_api.py
......F.F...................
======================================================================
FAIL: test_batchnorm_testing_gpu (__main__.TestAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_api.py", line 195, in test_batchnorm_testing_gpu
    _run_testing(x_0, s_0, b_0, rm_0, rv_0, m_0=1.0)
  File "test_api.py", line 186, in _run_testing
    y_1, tensor.to_numpy(_cTensor_to_pyTensor(y_2_c)), decimal=5)
  File "/usr/local/lib/python3.6/dist-packages/numpy/testing/_private/utils.py", line 1047, in assert_array_almost_equal
    precision=decimal)
  File "/usr/local/lib/python3.6/dist-packages/numpy/testing/_private/utils.py", line 846, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Arrays are not almost equal to 5 decimals

Mismatched elements: 4 / 16 (25%)
Max absolute difference: 4.4822693e-05
Max relative difference: 4.482269e-06
 x: array([[[[  1.     ,   1.     ],
         [  1.     ,   1.     ]],
...
 y: array([[[[  1.     ,   1.     ],
         [  1.     ,   1.     ]],
...

======================================================================
FAIL: test_batchnorm_training_gpu (__main__.TestAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_api.py", line 161, in test_batchnorm_training_gpu
    _run_training(x_0, s_0, b_0, rm_0, rv_0, m_0=0.2)
  File "test_api.py", line 132, in _run_training
    y_1, tensor.to_numpy(_cTensor_to_pyTensor(y_2_c)), decimal=5)
  File "/usr/local/lib/python3.6/dist-packages/numpy/testing/_private/utils.py", line 1047, in assert_array_almost_equal
    precision=decimal)
  File "/usr/local/lib/python3.6/dist-packages/numpy/testing/_private/utils.py", line 846, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Arrays are not almost equal to 5 decimals

Mismatched elements: 21881 / 40000 (54.7%)
Max absolute difference: 0.00010204
Max relative difference: 0.75810695
 x: array([[[[-7.11059e-01,  1.31187e+00,  1.10835e+00, ...,  6.71445e-01,
          -4.11530e-01,  7.55671e-01],
         [ 2.34414e-01,  1.75757e-02,  1.53543e+00, ..., -3.24708e-01,...
 y: array([[[[-7.11130e-01,  1.31193e+00,  1.10839e+00, ...,  6.71459e-01,
          -4.11583e-01,  7.55690e-01],
         [ 2.34401e-01,  1.75493e-02,  1.53550e+00, ..., -3.24755e-01,...

----------------------------------------------------------------------
Ran 28 tests in 1.582s
```