### PR TITLE
Fix SINGA-gpu conda build and update numpy version

### DIFF
--- a/src/core/device/cuda_gpu.cc
+++ b/src/core/device/cuda_gpu.cc
@@ -46,7 +46,8 @@ CudaGPU::~CudaGPU() {
 
   // Explicitly destroys and cleans up all resources associated with current
   // device
-  CUDA_CHECK(cudaDeviceReset());
+  cudaDeviceReset();
+  // the returned code incidate "driver shutting down" after reset
 }
 const int kNumCudaStream = 1;
 

--- a/src/core/tensor/math_kernel.cu
+++ b/src/core/tensor/math_kernel.cu
@@ -133,14 +133,14 @@ __global__ void KernelFloor(const size_t n, const float *in, float *out) {
 __global__ void KernelRound(const size_t n, const float *in, float *out) {
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
        i += blockDim.x * gridDim.x) {
-    out[i] = std::round(in[i]);
+    out[i] = roundf(in[i]);
   }
 }
 
 __global__ void KernelRoundE(const size_t n, const float *in, float *out) {
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
        i += blockDim.x * gridDim.x) {
-    out[i] = std::round(in[i]/2)*2;
+    out[i] = roundf(in[i]/2)*2;
   }
 }
 

--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - protobuf 3.10.0         # [osx]
     - protobuf 3.9.2          # [linux]
     - glog 0.3.5
-    - numpy 1.18.5
+    - numpy >=1.16,<2.0
     - pytest
     - deprecated 1.2.7
     - cudnn {{ cudnn }}       # ['cudnn' in str(build_str)]

--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -50,7 +50,7 @@ requirements:
     - protobuf 3.10.0         # [osx]
     - protobuf 3.9.2          # [linux]
     - glog 0.3.5
-    - numpy 1.16.5
+    - numpy 1.18.5
     - pytest
     - deprecated 1.2.7
     - cudnn {{ cudnn }}       # ['cudnn' in str(build_str)]


### PR DESCRIPTION
1. When I was building conda package of singa-gpu, I encountered the following error

![building](https://user-images.githubusercontent.com/38325429/86128724-53546000-bb14-11ea-8c1c-42bf5bf79b5c.png)

One available solution is to call `roundf` in CUDA MATH API instead of `std::round `
https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html#group__CUDA__MATH__SINGLE_1ga1c1521079e51b4f54771b16a7f8aeea

With this modification, the round test case can pass:
```
root@e7f452d7c67a:~/dcsysh/singa/test/python# python3 test_api.py
.................................
----------------------------------------------------------------------
Ran 33 tests in 1.409s

OK
```
By the way, in the docker version of singa, it does not need this change, maybe it is the difference of GCC version in the two environments.

2. This PR updates the numpy to 1.18.5

3. Seems the `cudaDeviceReset()` in destructor returns "driver shutting down" code, we don't need the `CUDA_CHECK`.

```
root@e7f452d7c67a:~/dcsysh/singa/test/python# python3 test_api.py
.................................
----------------------------------------------------------------------
Ran 33 tests in 1.383s

OK
WARNING: Logging before InitGoogleLogging() is written to STDERR
F0630 12:40:39.892601  3077 cuda_gpu.cc:49] Check failed: error == cudaSuccess (29 vs. 0)  driver shutting down
*** Check failure stack trace: ***
Aborted (core dumped)
```
After changed, it works well
```
root@e7f452d7c67a:~/dcsysh/singa/test/python# python3 test_api.py
.................................
----------------------------------------------------------------------
Ran 33 tests in 1.564s

OK
root@e7f452d7c67a:~/dcsysh/singa/test/python#
```
