### PR TITLE
Update CXX compiler to 7.5.0 in Conda version of SINGA to fix compile error

### DIFF
--- a/tool/conda/singa/conda_build_config.yaml
+++ b/tool/conda/singa/conda_build_config.yaml
@@ -18,9 +18,9 @@
 #
 
 c_compiler_version:         # [linux]
-    - 5.4                   # [linux]
+    - 7.5.0                 # [linux]
 cxx_compiler_version:       # [linux]
-    - 5.4                   # [linux]
+    - 7.5.0                 # [linux]
 # https://docs.conda.io/projects/conda-build/en/latest/resources/compiler-tools.html#macos-sdk
 CONDA_BUILD_SYSROOT:
     - "/tmp/MacOSX10.9.sdk" # [osx]


### PR DESCRIPTION
For conda version of SINGA:

This is to fix the issue in https://github.com/apache/singa/pull/758

It requires to use explicit type in cuda kernal, which cannot use "auto" instead

Upgrade the CXX compiler to 7.5.0 can solve the problem (note that the docker version of singa currently using 7.5.0 also)

```
[ 14%] Building NVCC (Device) object src/CMakeFiles/cuda_compile_1.dir/core/tensor/cuda_compile_1_generated_math_kernel.cu.o
/root/miniconda/conda-bld/singa_1593705642277/work/src/core/tensor/math_kernel.cu(143): error: explicit type is missing ("int" assu                                                               med)

1 error detected in the compilation of "/tmp/tmpxft_00000574_00000000-6_math_kernel.cpp1.ii".
CMake Error at cuda_compile_1_generated_math_kernel.cu.o.cmake:280 (message):
  Error generating file
  /root/miniconda/conda-bld/singa_1593705642277/work/build/src/CMakeFiles/cuda_compile_1.dir/core/tensor/./cuda_compile_1_generated                                                               _math_kernel.cu.o
```
