### PR TITLE
Adding dependabot support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot is a native tool in github that automatically checks the dependencies of the project and creates pull requests for outdated or insecure dependencies. See how it works from [here](https://dependabot.com/#how-it-works).

Currently it will analyze only the dependencies defined in [pom.xml ](https://github.com/apache/singa/blob/master/java/pom.xml)in SINGA because other dependencies are hard coded in configuration or shell scripts which are not supported by this tool. In future commits, the dependencies will be moved to standard files such as python requirements.txt so that they become available to dependabot and similar tools.