### PR TITLE
conda build and test with Github Actions

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is a basic workflow to help you get started with Actions
+
+name: conda
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+  pull_request:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-ubuntu-conda:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: install-conda-build
+        run: conda install conda-build
+      - name: conda-config
+        run: conda config --add channels conda-forge && conda config --add channels nusdbsystem
+      - name: build-singa-conda
+        run: conda build tool/conda/singa

--- a/test/python/run.py
+++ b/test/python/run.py
@@ -16,11 +16,15 @@
 # limitations under the License.
 #
 
+import sys
 import unittest
-# import xmlrunner
 
-loader = unittest.TestLoader()
-tests = loader.discover('.')
-testRunner = unittest.runner.TextTestRunner()
-# testRunner = xmlrunner.XMLTestRunner(output='.')
-testRunner.run(tests)
+def main():
+    loader = unittest.TestLoader()
+    tests = loader.discover('.')
+    testRunner = unittest.runner.TextTestRunner()
+    ret = not testRunner.run(tests).wasSuccessful()
+    sys.exit(ret)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I used the fix proposed at [PR 457 ](https://github.com/apache/singa/pull/457) and added the Github action to build and test with conda.

As discussed in the PR 457: `This PR is required for enabling the python test with continuous integration. Without this PR, the user must check the error messages of the python test manually by looking at the log and the python test errors are not shown as check errors in Travis CI or Github Actions.`

Currently both Github actions and Travis CI (correctly) fail because of the python test errors. 