### PR TITLE
Add code coverage for C++

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -49,12 +49,14 @@ jobs:
       - name: get-oneDNN
         run: wget https://github.com/oneapi-src/oneDNN/releases/download/v1.1/dnnl_lnx_1.1.0_cpu_gomp.tgz -P /tmp/ && tar zxf /tmp/dnnl_lnx_1.1.0_cpu_gomp.tgz -C /tmp
       - name: install-build-dependencies
-        run: sudo apt-get install -y libgoogle-glog-dev libprotobuf-dev protobuf-compiler libncurses-dev libopenblas-dev gfortran libblas-dev liblapack-dev libatlas-base-dev swig libcurl3-dev cmake dh-autoreconf
+        run: sudo apt-get install -y libgoogle-glog-dev libprotobuf-dev protobuf-compiler libncurses-dev libopenblas-dev gfortran libblas-dev liblapack-dev libatlas-base-dev swig dh-autoreconf lcov
       - name: configure
-        run: mkdir build && cd build && cmake -DUSE_PYTHON=NO -DENABLE_TEST=YES -DUSE_DNNL=YES ..
+        run: mkdir build && cd build && cmake -DUSE_PYTHON=NO -DENABLE_TEST=YES -DCODE_COVERAGE=YES -DUSE_DNNL=YES ..
         env:
          DNNL_ROOT: /tmp/dnnl_lnx_1.1.0_cpu_gomp/
       - name: build
         run: cd build && make
       - name: C++ test
         run: build/bin/test_singa
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ INCLUDE_DIRECTORIES(${SINGA_INCLUDE_DIR})
 
 OPTION(USE_CUDA "Use Cuda libs" OFF)
 OPTION(ENABLE_TEST "Enable unit test" OFF)
+option(CODE_COVERAGE "Enable coverage reporting" OFF)
 OPTION(USE_PYTHON "Generate py wrappers" ON)
 OPTION(USE_PYTHON3 "Python 3x" OFF)
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Distributed deep learning system
 
 ![LGTM C++ Grade](https://img.shields.io/lgtm/grade/cpp/github/apache/incubator-singa)
 ![LGTM Python Grade](https://img.shields.io/lgtm/grade/python/github/apache/incubator-singa)
+[![codecov](https://codecov.io/gh/apache/singa/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/singa)
 
 [![Stargazers over time](https://starchart.cc/apache/singa.svg)](https://starchart.cc/apache/singa)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,11 @@ IF(UNIX OR APPLE)
   SET_TARGET_PROPERTIES(singa PROPERTIES LINK_FLAGS "")
 ENDIF()
 
+IF(CODE_COVERAGE)
+    MESSAGE("-- Enabling Code Coverage")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g --coverage")
+ENDIF(CODE_COVERAGE)
+
 #pass configure infor to swig
 FILE(REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/api/config.i")
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/api/config.i.in" "${CMAKE_CURRENT_SOURCE_DIR}/api/config.i")


### PR DESCRIPTION
Adding C++ code coverage and uploading the report to codecov.io. 

The coverage badge on README shows coverage on Apache master branch, so it will be active when this commit is merged into the master branch. To check coverage on other branches such as dev, simply visit https://codecov.io/gh/apache/singa/ (after merging this PR and completing the github action).

Currently the C++ coverage is around 65%. Later we will add the python code coverage also.