### PR TITLE
Fix test cases error

### DIFF
--- a/python/singa/autograd.py
+++ b/python/singa/autograd.py
@@ -3942,13 +3942,16 @@ class Dropout(Operator):
     `output = scale * data * mask`, `scale = 1. / (1. - ratio)`.
     """
 
-    def __init__(self, ratio=0.5):
+    def __init__(self, seed=0, ratio=0.5):
         """
         Args:
+            seed (int): the random seed
             ratio (float): the ratio of random dropout, with value in [0, 1).
         """
         super(Dropout, self).__init__()
         self.ratio = ratio
+        self.seed = int(seed)
+        self.init_seed = False
 
     def forward(self, x):
         """
@@ -3958,6 +3961,9 @@ class Dropout(Operator):
         Returns:
             the output CTensor.
         """
+        if not self.init_seed:
+            x.device().SetRandSeed(self.seed)
+            self.init_seed = True
         if training:
             self.scale = 1 / 1 - self.ratio
             self.mask = singa.Tensor(list(x.shape()), x.device())
@@ -3978,7 +3984,7 @@ class Dropout(Operator):
         return dy
 
 
-def dropout(x, ratio=0.5):
+def dropout(x, seed=0, ratio=0.5):
     """
     Init a Dropout, which scales the masked input data by the following
     equation: `output = scale * data * mask`, `scale = 1. / (1. - ratio)`.
@@ -3988,7 +3994,7 @@ def dropout(x, ratio=0.5):
     Returns:
         the output Tensor.
     """
-    return Dropout(ratio)(x)[0]
+    return Dropout(seed, ratio)(x)[0]
 
 
 class ReduceSum(Operator):

--- a/python/singa/sonnx.py
+++ b/python/singa/sonnx.py
@@ -1337,8 +1337,9 @@ class SingaBackend(Backend):
         Returns: 
             singa operator instance
         """
+        seed = onnx_node.getattr("seed", 0)
         ratio = onnx_node.getattr("ratio", 0)
-        return operator(ratio)
+        return operator(seed, ratio)
 
     @classmethod
     def _create_constant_of_shape(cls,

--- a/test/python/test_onnx_backend.py
+++ b/test/python/test_onnx_backend.py
@@ -105,18 +105,26 @@ for pattern in _exclude_nodes_patterns:
 if not singa.USE_CUDA:
     backend_test.exclude(r'(cuda)')
 
+OnnxBackendNodeModelTest = backend_test.enable_report().test_cases['OnnxBackendNodeModelTest']
+
+# disable and enable training before and after test cases
+def setUp(self):
+    # print("\nIn method", self._testMethodName)
+    autograd.training = False
+
+def tearDown(self):
+    autograd.training = True
+
+OnnxBackendNodeModelTest.setUp = setUp
+OnnxBackendNodeModelTest.tearDown = tearDown
+
 # import all test cases at global scope to make them visible to python.unittest
 # print(backend_test.enable_report().test_cases)
 test_cases = {
-    'OnnxBackendNodeModelTest':
-        backend_test.enable_report().test_cases['OnnxBackendNodeModelTest']
+    'OnnxBackendNodeModelTest': OnnxBackendNodeModelTest
 }
 
 globals().update(test_cases)
-
-# def setUp(self):
-#     print("\nIn method", self._testMethodName)
-# OnnxBackendNodeModelTest.setUp = setUp
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since the ONNX test cases assume it works in an inference environment, so this PR explicitly to enable and disable the training mode before and after the ONNX test cases.

BTW,

Add random seed to dropout operator.