### PR TITLE
code coverage for python

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ignore:
+  - proto/*

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -38,3 +38,5 @@ jobs:
         run: conda config --add channels conda-forge && conda config --add channels nusdbsystem
       - name: build-pytest
         run: conda build tool/conda/singa
+        env:
+          TEST_COMMAND: pytest --cov=$PREFIX/lib/python3.7/site-packages/singa --cov-report=xml && codecov --flags singa-python

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -60,3 +60,5 @@ jobs:
         run: build/bin/test_singa
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+        with:
+          flags: singa-cpp

--- a/tool/conda/singa/meta.yaml
+++ b/tool/conda/singa/meta.yaml
@@ -75,14 +75,16 @@ requirements:
     - tqdm
     - onnx 1.6.0
     - deprecated 1.2.7
-    - pytest
-
+    
 test:
+  requires:
+    - pytest-cov
+    - tabulate
+    - codecov
   source_files:
     - test/python/*.py
   commands:
-    - cd test/python && python run.py
-
+    - {{ environ.get('TEST_COMMAND', 'cd test/python && python run.py') }}
 about:
   home: http://singa.apache.org/
   license: Apache V2


### PR DESCRIPTION
Run python test from the conda build and merge the python coverage report with the C++ coverage report. The python coverage ignores the proto directory.