### PR TITLE
Add new cpu conda build dockerfile and Add new readme

### DIFF
--- a/tool/conda/README.md
+++ b/tool/conda/README.md
@@ -23,7 +23,9 @@ This note is written for the repo maintainer.
 
 To create conda package and upload, you can follow the following steps:
 
-## 1. Build the docker image from https://github.com/apache/singa/blob/dev/tool/conda/docker/cuda10/Dockerfile
+## 1. Build the docker image
+
+To have the build environment, use the dockerfile from https://github.com/apache/singa/blob/dev/tool/conda/docker/cuda10/Dockerfile
 
 For example:
 

--- a/tool/conda/README.md
+++ b/tool/conda/README.md
@@ -1,0 +1,68 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Package SINGA using conda-build
+
+This note is written for the repo maintainer.
+
+To create conda package and upload, you can follow the following steps:
+
+1. Build the docker image from https://github.com/apache/singa/blob/dev/tool/conda/docker/cuda10/Dockerfile
+
+For example:
+
+    docker build SINGA_DIR/singa/tool/conda/docker/cpu -t nusdbsystem/singa:conda-cpu
+
+2. Build the container from the image and access the container
+
+For example:
+
+    docker run -it -p 2222:22 --runtime nvidia --name singa_conda_cpu --rm nusdbsystem/singa:conda-cpu bash
+
+3. There are three versions of conda package: (i) CPU, (ii) GPU, and (iii) DIST (distributed training)
+
+To build the specific versions, follow the steps: 
+
+(i) cd to the folder tool/conda/singa, follow the instruction in https://github.com/apache/singa/blob/dev/tool/conda/singa/README.md
+
+For example, for CPU version:
+
+    conda config --add channels conda-forge
+    conda config --add channels nusdbsystem
+    conda-build .  --python 3.6
+    anaconda -t $ANACONDA_UPLOAD_TOKEN upload -u nusdbsystem -l main /root/miniconda/conda-bld/linux-64/singa-3.1.0-cpu_py36.tar.bz2
+
+The above will generate the SINGA package. The next step will be wrapping it to generate SINGA-CPU / SINGA-GPU / SINGA-DIST conda packages.
+
+(ii) For different versions, cd to different folder:
+
+For CPU version, cd to tool/conda/cpu
+For GPU version, cd to tool/conda/gpu
+For DIST version, cd to tool/conda/dist
+
+(iii) Generate the SINGA-CPU / SINGA-GPU / SINGA-DIST anaconda package and upload.
+
+For an example of SINGA-CPU version:
+
+    conda config --add channels conda-forge
+    conda config --add channels nusdbsystem
+    conda-build .  --python 3.6
+    anaconda -t $ANACONDA_UPLOAD_TOKEN upload -u nusdbsystem -l main /root/miniconda/conda-bld/linux-64/singa-cpu-3.1.0-py36.tar.bz2
+
+Since SINGA-CPU, SINGA-GPU and SINGA-DIST packages are wrapped from SINGA package, the steps from (i) to (iii) are necessary.

--- a/tool/conda/README.md
+++ b/tool/conda/README.md
@@ -23,19 +23,21 @@ This note is written for the repo maintainer.
 
 To create conda package and upload, you can follow the following steps:
 
-1. Build the docker image from https://github.com/apache/singa/blob/dev/tool/conda/docker/cuda10/Dockerfile
+## 1. Build the docker image from https://github.com/apache/singa/blob/dev/tool/conda/docker/cuda10/Dockerfile
 
 For example:
 
     docker build SINGA_DIR/singa/tool/conda/docker/cpu -t nusdbsystem/singa:conda-cpu
 
-2. Build the container from the image and access the container
+## 2. Build the container from the image and access the container
 
 For example:
 
     docker run -it -p 2222:22 --runtime nvidia --name singa_conda_cpu --rm nusdbsystem/singa:conda-cpu bash
 
-3. There are three versions of conda package: (i) CPU, (ii) GPU, and (iii) DIST (distributed training)
+## 3. Build conda packages
+
+There are three versions of conda package: (i) CPU, (ii) GPU, and (iii) DIST (distributed training)
 
 To build the specific versions, follow the steps: 
 

--- a/tool/conda/README.md
+++ b/tool/conda/README.md
@@ -47,6 +47,7 @@ To build the specific versions, follow the steps:
 
 For example, for CPU version:
 
+    cd tool/conda/singa
     conda config --add channels conda-forge
     conda config --add channels nusdbsystem
     conda-build .  --python 3.6
@@ -64,8 +65,7 @@ For DIST version, cd to tool/conda/dist
 
 For an example of SINGA-CPU version:
 
-    conda config --add channels conda-forge
-    conda config --add channels nusdbsystem
+    cd tool/conda/cpu
     conda-build .  --python 3.6
     anaconda -t $ANACONDA_UPLOAD_TOKEN upload -u nusdbsystem -l main /root/miniconda/conda-bld/linux-64/singa-cpu-3.1.0-py36.tar.bz2
 

--- a/tool/conda/cpu/README.md
+++ b/tool/conda/cpu/README.md
@@ -42,7 +42,7 @@ change the dependency.
 To build this package and upload it
 
     conda config --add channels nusdbsystem
-    conda build .
+    conda-build .  --python 3.6
     anaconda -t $ANACONDA_UPLOAD_TOKEN upload -u nusdbsystem -l main <path to the singa-cpu package>
 
 where $ANACONDA_UPLOAD_TOKEN is the upload token associated with nusdbsystem account on anaconda cloud.

--- a/tool/conda/dist/README.md
+++ b/tool/conda/dist/README.md
@@ -45,7 +45,7 @@ change the dependency.
 To build this package and upload it
 
     conda config --add channels nusdbsystem
-    conda build .
+    conda-build .  --python 3.6
     anaconda -t $ANACONDA_UPLOAD_TOKEN upload -u nusdbsystem -l main <path to the singa-dist package>
 
 where $ANACONDA_UPLOAD_TOKEN is the upload token associated with nusdbsystem account on anaconda cloud.

--- a/tool/conda/docker/cpu/Dockerfile
+++ b/tool/conda/docker/cpu/Dockerfile
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# 18.04 has erros in ssh
+FROM ubuntu:18.04
+
+# install dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        cmake \
+        wget \
+        openssh-server \
+        ca-certificates \
+    && apt-get clean \
+    && apt-get autoremove \
+    && apt-get autoclean \
+    && rm -rf /var/lib/apt/lists/* \
+    #
+    # install conda, conda-build and anaconda-client
+    #
+    && wget --no-check-certificate https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh \
+    && bash miniconda.sh -b -p /root/miniconda \
+    && /root/miniconda/bin/conda config --set always_yes yes --set changeps1 no \
+    && /root/miniconda/bin/conda update -q conda \
+    && /root/miniconda/bin/conda install -y \
+        conda-build \
+        anaconda-client \
+    && /root/miniconda/bin/conda clean -tipsy
+
+# config ssh service
+RUN mkdir /var/run/sshd \
+    && echo 'root:singa' | chpasswd \
+    && sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config \
+    && mkdir /root/.ssh
+
+# Add conda to PATH. Doing this here so other RUN steps can be grouped above
+ENV PATH /root/miniconda/bin:${PATH}
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/tool/conda/gpu/README.md
+++ b/tool/conda/gpu/README.md
@@ -44,7 +44,7 @@ change the dependency.
 To build this package and upload it
 
     conda config --add channels nusdbsystem
-    conda build .
+    conda-build .  --python 3.6
     anaconda -t $ANACONDA_UPLOAD_TOKEN upload -u nusdbsystem -l main <path to the singa-cpu package>
 
 where $ANACONDA_UPLOAD_TOKEN is the upload token associated with nusdbsystem account on anaconda cloud.


### PR DESCRIPTION
This PR has two purposes:

(i) Add a cpu conda build dockerfile, this is useful when the computer does not have gpu but we still want to build cpu package

(ii) Add new readme file on how to generate new conda packages