### PR TITLE
Fix the conda-build version that does not work recently

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: install-conda-build
-        run: conda install conda-build anaconda-client
+        run: conda install conda-build=3.20.4 anaconda-client
       - name: conda-config
         run: conda config --add channels conda-forge && conda config --add channels nusdbsystem && conda config --set anaconda_upload no
       - name: build-pytest


### PR DESCRIPTION
Recently, without version locking, the conda-build version is 3.21, where conda build cannot start run for python 3.6, so the test in "conda / build-pytest-package-ubuntu" does not work

Therefore, I lock the version of conda-build to be 3.20.4, it works well as before