### PR TITLE
Switch between CPU and GPU devices for cifar_distributed_cnn example

### DIFF
--- a/examples/cifar_distributed_cnn/train_cnn.py
+++ b/examples/cifar_distributed_cnn/train_cnn.py
@@ -111,7 +111,7 @@ def run(global_rank,
         dist_option='plain',
         spars=None,
         precision='float32'):
-    dev = device.create_cuda_gpu_on(local_rank)
+    dev = device.create_cuda_gpu_on(local_rank)  # need to change to CPU device for CPU-only machines
     dev.SetRandSeed(0)
     np.random.seed(0)
 


### PR DESCRIPTION
1. Switch between CPU and GPU devices for cifar_distributed_cnn example