### PR TITLE
Collections.Iterable Update to support Python 3.10

### DIFF
--- a/examples/model_selection/Trails/internal/ml/model_selection/src/eva_engine/phase1/algo/singa_ms/cnn_ms/pkg_model_code/model.py
+++ b/examples/model_selection/Trails/internal/ml/model_selection/src/eva_engine/phase1/algo/singa_ms/cnn_ms/pkg_model_code/model.py
@@ -27,7 +27,7 @@ import json
 import zipfile
 import numpy as np
 from functools import wraps
-from collections import Iterable
+from collections.abc import Iterable
 
 from singa import tensor
 from singa import autograd

--- a/python/singa/model.py
+++ b/python/singa/model.py
@@ -27,7 +27,7 @@ import json
 import zipfile
 import numpy as np
 from functools import wraps
-from collections import Iterable
+from collections.abc import Iterable
 
 from singa import tensor
 from singa import autograd

--- a/python/singa/sonnx.py
+++ b/python/singa/sonnx.py
@@ -900,7 +900,7 @@ class SingaFrontend(object):
         else:
             translator = cls._common_singa_tensor_to_onnx_node
         nodes = translator(op, op_t)
-        if not isinstance(nodes, collections.Iterable):
+        if not isinstance(nodes, collections.abc.Iterable):
             nodes = [nodes]
         nodes = [node for node in nodes if node is not None]
         return nodes
@@ -1826,7 +1826,7 @@ class SingaBackend(Backend):
             list, the output
         """
         outputs = operator(*inputs)
-        if not isinstance(outputs, collections.Iterable):
+        if not isinstance(outputs, collections.abc.Iterable):
             outputs = [outputs]
         return outputs
 


### PR DESCRIPTION
Referring to this issue
https://github.com/apache/singa/issues/1164

Iterable class exists in collections.abc since Python 3.3.
https://docs.python.org/3.3/library/collections.abc.html#collections.abc.Iterable

Replaced all collections.Iterable  with collections.abs.Iterable in project except this one, someone made it this way
https://github.com/apache/singa/blob/6d9cd7f9ab6e1ce3caac381db586814464fe5511/examples/model_selection/Trails/singa_pkg_code/model.py#L32-L35
