### PR TITLE
CI: update Ubuntu runner image

### DIFF
--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -42,7 +42,7 @@ jobs:
   #      run: build/bin/test_singa
 
   build-cpptest-on-cpu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
## Summary

  Update the GitHub Actions Ubuntu runner used by the `Native-Ubuntu` workflow:

  ```diff
  - runs-on: ubuntu-20.04
  + runs-on: ubuntu-24.04
```

  ## Why

  The Native-Ubuntu / build-cpptest-on-cpu job was staying queued and never receiving a runner because ubuntu-20.04 is no longer available as a GitHub-hosted runner image.

  Updating the workflow to ubuntu-24.04 allows GitHub Actions to assign a runner and execute the C++ CPU build/test job.

   ## Result:

  [  PASSED  ] 171 tests.
