### PR TITLE
Fix Read the Docs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,11 +17,12 @@
 
 # .readthedocs.yml
 build:
-  image: stable
+  os: ubuntu-24.04
+  tools:
+    python: "miniforge3-latest"
+
 conda:
   environment: doc/environment.yml
-python:
-    version: 3.7
 
 # Required
 version: 2


### PR DESCRIPTION
 Updates the Read the Docs configuration to use the current v2 schema with an explicit Ubuntu 24.04 build image and supported Miniforge-based Conda tooling.

  * Replace deprecated `build.image` and `python.version` settings
  * Use `ubuntu-24.04` for the RTD build OS
  * Use `miniforge3-latest` for the Conda environment manager
  * Keep the existing Conda environment and Sphinx configuration paths

 This is expected to fix the failing documentation status badge in the README, but the badge result cannot be fully verified until the change is merged into the branch/version used by Read the Docs.


  Created-by: Codex
  Reviewed-by: Moaz Reyad
