### PR TITLE
DOC: update Ubuntu workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 # Apache SINGA
 
-![Native Ubuntu build status](https://github.com/apache/singa/workflows/Native-Ubuntu/badge.svg)
+[![Native-Ubuntu](https://github.com/apache/singa/actions/workflows/ubuntu.yaml/badge.svg?branch=master)](https://github.com/apache/singa/actions/workflows/ubuntu.yaml)
 ![Native Mac build status](https://github.com/apache/singa/workflows/Native-MacOS/badge.svg)
 ![conda build status](https://github.com/apache/singa/workflows/conda/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/apache-singa/badge/?version=latest)](https://apache-singa.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
## Description

  This PR fixes the Native Ubuntu build status badge in the README by replacing GitHub’s old name-based badge URL with the current workflow-file-based URL.

  It extends #1401, which corrected the Ubuntu test workflow. Although the test was fixed, its status was not displayed correctly in the README because the badge still used the old URL format.

  The updated badge now points directly to .github/workflows/ubuntu.yaml and links to the corresponding GitHub Actions workflow page.
